### PR TITLE
tests.py: Non-zero exit code if tests fail

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -2,7 +2,8 @@
 import unittest
 import tempfile
 import pypandoc
-import os 
+import os
+import sys
 
 
 def test_converter(to, format=None, extra_args=()):
@@ -63,4 +64,5 @@ class TestPypandoc(unittest.TestCase):
         self.assertEqual(expected, received)
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestPypandoc)
-unittest.TextTestRunner(verbosity=2).run(suite)
+ret = unittest.TextTestRunner(verbosity=2).run(suite)
+sys.exit(0 if ret.wasSuccessful() else 1)


### PR DESCRIPTION
Important if this is going to be called by a CI system, tox, etc.

```
$ python tests.py
test_basic_conversion_from_file (__main__.TestPypandoc) ... FAIL
test_basic_conversion_from_file_with_format (__main__.TestPypandoc) ... FAIL
test_basic_conversion_from_string (__main__.TestPypandoc) ... FAIL
test_converts_valid_format (__main__.TestPypandoc) ... ok
test_does_not_convert_from_invalid_format (__main__.TestPypandoc) ... ok
test_does_not_convert_to_invalid_format (__main__.TestPypandoc) ... ok

======================================================================
FAIL: test_basic_conversion_from_file (__main__.TestPypandoc)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests.py", line 48, in test_basic_conversion_from_file
    self.assertEqual(expected, received)
AssertionError: u'some title\n==========\n\n' != u'some title\n==========\n'
  some title
  ==========
-


======================================================================
FAIL: test_basic_conversion_from_file_with_format (__main__.TestPypandoc)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests.py", line 59, in test_basic_conversion_from_file_with_format
    self.assertEqual(expected, received)
AssertionError: u'some title\n==========\n\n' != u'some title\n==========\n'
  some title
  ==========
-


======================================================================
FAIL: test_basic_conversion_from_string (__main__.TestPypandoc)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests.py", line 64, in test_basic_conversion_from_string
    self.assertEqual(expected, received)
AssertionError: u'some title\n==========\n\n' != u'some title\n==========\n'
  some title
  ==========
-


----------------------------------------------------------------------
Ran 6 tests in 0.741s

FAILED (failures=3)

$ echo $?
1
```