### PR TITLE
Fix test failures

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -44,7 +44,7 @@ class TestPypandoc(unittest.TestCase):
             test_file.flush()
         expected = u'some title{0}=========={0}{0}'.format(os.linesep)
         received = pypandoc.convert(file_name, 'rst')
-        self.assertEqual(expected, received)
+        self.assertEqualExceptForNewlineEnd(expected, received)
 
     def test_basic_conversion_from_file_with_format(self):
         # This will not work on windows:
@@ -55,12 +55,16 @@ class TestPypandoc(unittest.TestCase):
             test_file.flush()
         expected = u'some title{0}=========={0}{0}'.format(os.linesep)
         received = pypandoc.convert(file_name, 'rst', format='md')
-        self.assertEqual(expected, received)
+        self.assertEqualExceptForNewlineEnd(expected, received)
 
     def test_basic_conversion_from_string(self):
         expected = u'some title{0}=========={0}{0}'.format(os.linesep)
         received = pypandoc.convert('#some title', 'rst', format='md')
-        self.assertEqual(expected, received)
+        self.assertEqualExceptForNewlineEnd(expected, received)
+
+    def assertEqualExceptForNewlineEnd(self, expected, received):
+        self.assertEqual(expected.rstrip('\n'), received.rstrip('\n'))
+
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestPypandoc)
 unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
b/c differing # of newlines at ends of expected and received output.

Was getting the following on OS X, with pandoc 1.13.2:

```
$ python tests.py
test_basic_conversion_from_file (__main__.TestPypandoc) ... FAIL
test_basic_conversion_from_file_with_format (__main__.TestPypandoc) ... FAIL
test_basic_conversion_from_string (__main__.TestPypandoc) ... FAIL
test_converts_valid_format (__main__.TestPypandoc) ... ok
test_does_not_convert_from_invalid_format (__main__.TestPypandoc) ... ok
test_does_not_convert_to_invalid_format (__main__.TestPypandoc) ... ok

======================================================================
FAIL: test_basic_conversion_from_file (__main__.TestPypandoc)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests.py", line 48, in test_basic_conversion_from_file
    self.assertEqual(expected, received)
AssertionError: u'some title\n==========\n\n' != u'some title\n==========\n'
  some title
  ==========
-

======================================================================
FAIL: test_basic_conversion_from_file_with_format (__main__.TestPypandoc)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests.py", line 59, in test_basic_conversion_from_file_with_format
    self.assertEqual(expected, received)
AssertionError: u'some title\n==========\n\n' != u'some title\n==========\n'
  some title
  ==========
-

======================================================================
FAIL: test_basic_conversion_from_string (__main__.TestPypandoc)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests.py", line 64, in test_basic_conversion_from_string
    self.assertEqual(expected, received)
AssertionError: u'some title\n==========\n\n' != u'some title\n==========\n'
  some title
  ==========
-

----------------------------------------------------------------------
Ran 6 tests in 0.741s

FAILED (failures=3)

$ echo $?
1
```