### PR TITLE
Add tox.ini for tox (http://tox.testrun.org)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 dist/
 pypandoc.egg-info/
+.tox/

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist = py26, py27, py33, py34, pypy, pypy3, flake8
+
+[testenv]
+commands =
+    python tests.py
+
+[testenv:flake8]
+basepython = python2.6
+deps =
+    flake8
+commands =
+    flake8 pypandoc.py tests.py


### PR DESCRIPTION
tox runs tests in multiple Python environments (including multiple Python versions)

http://tox.testrun.org/

```
$ pip install tox
...
$ tox
...
  py26: commands succeeded
  py27: commands succeeded
ERROR:   py33: InvocationError: /Users/marca/dev/git-repos/pypandoc/.tox/py33/bin/pip install --pre -U --no-deps /Users/marca/dev/git-repos/pypandoc/.tox/dist/pypandoc-0.8.6.zip (see /Users/marca/dev/git-repos/pypandoc/.tox/py33/log/py33-3.log)
ERROR:   py34: InvocationError: /Users/marca/dev/git-repos/pypandoc/.tox/py34/bin/pip install --pre -U --no-deps /Users/marca/dev/git-repos/pypandoc/.tox/dist/pypandoc-0.8.6.zip (see /Users/marca/dev/git-repos/pypandoc/.tox/py34/log/py34-3.log)
  pypy: commands succeeded
ERROR:   pypy3: InvocationError: /Users/marca/dev/git-repos/pypandoc/.tox/pypy3/bin/pip install --pre -U --no-deps /Users/marca/dev/git-repos/pypandoc/.tox/dist/pypandoc-0.8.6.zip (see /Users/marca/dev/git-repos/pypandoc/.tox/pypy3/log/pypy3-3.log)
ERROR:   flake8: commands failed
```