### PR TITLE
Fix Python 3 `except` clause problem

### DIFF
--- a/pypandoc.py
+++ b/pypandoc.py
@@ -68,7 +68,7 @@ def _process_file(source, to, format, extra_args):
 
     try:
         c = p.communicate(source.encode('utf-8'))[0].decode('utf-8')
-    except UnicodeDecodeError, UnicodeEncodeError:
+    except (UnicodeDecodeError, UnicodeEncodeError):
         c = p.communicate(source)[0]
 
     return c


### PR DESCRIPTION
Tox (See https://github.com/bebraw/pypandoc/pull/22) will help prevent problems like this.

```
$ pip install tox
...
$ tox
...
  py26: commands succeeded
  py27: commands succeeded
  py33: commands succeeded
  py34: commands succeeded
  pypy: commands succeeded
  pypy3: commands succeeded
ERROR:   flake8: commands failed
```