### PR TITLE
Tox and travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 dist/
 pypandoc.egg-info/
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+sudo: false
+addons:
+  apt_packages:
+    - pandoc
+env:
+  - TOXENV=py26
+  - TOXENV=py27
+  - TOXENV=py33
+  - TOXENV=py34
+  - TOXENV=pypy
+  - TOXENV=flake8
+install:
+  - travis_retry pip install tox
+script:
+  - tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist = py26, py27, py33, py34, pypy, pypy3, flake8
+
+[testenv]
+commands =
+    python tests.py
+
+[testenv:flake8]
+basepython = python2.6
+deps =
+    flake8
+commands =
+    flake8 pypandoc.py tests.py


### PR DESCRIPTION
This adds support for both Tox (also in https://github.com/bebraw/pypandoc/pull/22) and Travis CI.

Passing Travis CI build for my fork: https://travis-ci.org/msabramo/pypandoc/builds/48974497

To enable for your repo: follow the steps at http://docs.travis-ci.com/user/getting-started/ and then merge this PR.

Note there are failures for Python 3, flake8, etc. which are fixed by my other PRs.