### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# --------------------------------------------------------------------------
+# This is a Dockerfile to build an Ubuntu 14.04 Docker image with pypandoc
+# and pandoc
+#
+# Use a command like:
+#     docker build -t <user>/pypandoc .
+# --------------------------------------------------------------------------
+
+FROM  orchardup/python:2.7
+MAINTAINER  Marc Abramowitz <marc@marc-abramowitz.com> (@msabramo)
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV LC_ALL C
+
+RUN apt-get update && apt-get install -y pandoc ipython
+ADD . pypandoc
+WORKDIR pypandoc
+RUN python setup.py install
+
+RUN mkdir -p /source
+WORKDIR /source
+
+CMD ["/usr/bin/python"]


### PR DESCRIPTION
This illustrates how to build a Docker image with pandoc and pypandoc in it.

I've uploaded an image to the Docker registry as [`msabramo/pypandoc`](https://registry.hub.docker.com/u/msabramo/pypandoc/) so you can use right away as seen below:

```
[marca@marca-mac2 pypandoc]$ docker run -v `pwd`:/source -it msabramo/pypandoc
Python 2.7.6 (default, Mar 22 2014, 22:59:56)
[GCC 4.8.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import pypandoc
>>> print(pypandoc.convert('README.md', 'rst'))
pypandoc
========

pypandoc provides a thin wrapper for
`pandoc <http://johnmacfarlane.net/pandoc/>`__, a universal document
converter.

Usage
-----

The basic invocation looks like this:
``pypandoc.convert('input', 'output format')``. ``pypandoc`` tries to
infer the type of the input automatically. If it's a file, it will load
it. In case you pass a string, you can define the ``format`` using the
parameter. The example below should clarify the usage:

.. code:: python

    import pypandoc

    output = pypandoc.convert('somefile.md', 'rst')

    # alternatively you could just pass some string to it and define its format
    output = pypandoc.convert('#some title', 'rst', format='md')
    # output == 'some title\r\n==========\r\n\r\n'

In addition to ``format``, it is possible to pass ``extra_args``. That
makes it possible to access various pandoc options easily.

.. code:: python

    output = pypandoc.convert('<h1>Primary Heading</h1>', 'md', format='html', extra_args=['--atx-headers'])
    # output == '# Primary Heading\r\n'
    output = pypandoc.convert('# Primary Heading', 'html', format='md', extra_args=['--base-header-level=2'])
    # output == '<h2 id="primary-heading">Primary Heading</h2>\r\n'

Please refer to ``pandoc -h`` and the `official
documentation <http://johnmacfarlane.net/pandoc/README.html>`__ for
further details.

See also `pyandoc <http://pypi.python.org/pypi/pyandoc/>`__ for an
alternative implementation.

Django Service Example
----------------------

See ``services.py`` at the project root for implementation. Use it like
this:

.. code:: python

    from .services import PandocDocxService

    service = PandocDocxService()
    doc_file = service.generate(html='<html><body><h1>Heading 1</h1><p>testing testing 123</p></body></html>')

Contributors
------------

-  `Valentin Haenel <https://github.com/esc>`__ - String conversion fix
-  `Daniel Sanchez <https://github.com/ErunamoJAZZ>`__ - Automatic
   parsing of input/output formats
-  `Thomas G. <https://github.com/coldfix>`__ - Python 3 support
-  `Ben Jao Ming <https://github.com/benjaoming>`__ - Fail gracefully if
   ``pandoc`` is missing
-  `Ross Crawford-d'Heureuse <http://github.com/rosscdh>`__ - Encode
   input in UTF-8 and add Django example
-  `Michael Chow <https://github.com/machow>`__ - Decode output in UTF-8
-  `Janusz Skonieczny <https://github.com/wooyek>`__ - Support Windows
   newlines and allow encoding to be specified.
-  `gabeos <https://github.com/gabeos>`__ - Fix help parsing
-  `Marc Abramowitz <https://github.com/msabramo>`__ - Make ``setup.py``
   fail hard if ``pandoc`` is missing
-  `Daniel L. <https://github.com/mcktrtl>`__ - Add ``extra_args``
   example to README
-  `Amy Guy <https://github.com/rhiaro>`__ - Exception handling for
   unicode errors

License
-------

``pypandoc`` is available under MIT license. See LICENSE for more
details.

>>>
[marca@marca-mac2 pypandoc]$
```