### PR TITLE
README.rst: Remove "Django" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,21 +40,6 @@ Please refer to `pandoc -h` and the [official documentation](http://johnmacfarla
 
 See also [pyandoc](http://pypi.python.org/pypi/pyandoc/) for an alternative implementation.
 
-## Django Service Example
-
-See `services.py` at the project root for implementation. Use it like this:
-
-```python
-from .services import PandocDocxService
-
-service = PandocDocxService()
-doc_file = service.generate(
-    '<html><body>'
-    '<h1>Heading 1</h1>'
-    '<p>testing testing 123</p>'
-    '</body></html>')
-```
-
 ## Contributors
 
 * [Valentin Haenel](https://github.com/esc) - String conversion fix


### PR DESCRIPTION
I find this example to be confusing, because:

- It's not really Django-specific though it specifically mentions Django. 
- The implementation is in a separate file that is not shown. This is the part that uses pypandoc. The code in README.md uses an API defined in that sample file, which is an API not provided by pandoc. 
- It's too complex for something to show in a README.