### PR TITLE
Allow Markdown extensions in output format

### DIFF
--- a/pypandoc.py
+++ b/pypandoc.py
@@ -51,9 +51,12 @@ def _convert(reader, processor, source, to,
             'Invalid input format! Expected one of these: ' +
             ', '.join(from_formats))
 
-    if to not in to_formats:
+    # Markdown syntax extensions can be individually enabled or disabled by
+    # appending +EXTENSION or -EXTENSION to the format name.
+    to_base = re.split('\+|-', to)[0]
+    if to_base not in to_formats:
         raise RuntimeError(
-            'Invalid to format! Expected one of these: ' +
+            'Invalid output format! Expected one of these: ' +
             ', '.join(to_formats))
 
     return processor(source, to, format, extra_args)

--- a/tests.py
+++ b/tests.py
@@ -65,6 +65,15 @@ class TestPypandoc(unittest.TestCase):
         received = pypandoc.convert('#some title', 'rst', format='md')
         self.assertEqualExceptForNewlineEnd(expected, received)
 
+    def test_conversion_with_markdown_extensions(self):
+        input = '<s>strike</s>'
+        expected_with_extension = u'~~strike~~'
+        expected_without_extension = u'<s>strike</s>'
+        received_with_extension = pypandoc.convert(input, 'markdown+strikeout', format='html')
+        received_without_extension = pypandoc.convert(input, 'markdown-strikeout', format='html')
+        self.assertEqualExceptForNewlineEnd(expected_with_extension, received_with_extension)
+        self.assertEqualExceptForNewlineEnd(expected_without_extension, received_without_extension)
+
     def assertEqualExceptForNewlineEnd(self, expected, received):
         self.assertEqual(expected.rstrip('\n'), received.rstrip('\n'))
 


### PR DESCRIPTION
From http://johnmacfarlane.net/pandoc/README.html#general-options:
> Markdown syntax extensions can be individually enabled or disabled by appending +EXTENSION or -EXTENSION to the format name. So, for example, ``markdown_strict+footnotes+definition_lists`` is strict markdown with footnotes and definition lists enabled.

Previously, pypandoc did not allow for such an output format to be given.