### PR TITLE
Stop flake8 complaining about imports not at top

### DIFF
--- a/pypandoc.py
+++ b/pypandoc.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
 from __future__ import with_statement
 
-__author__ = 'Juho Vepsäläinen'
-__version__ = '0.9.1'
-__license__ = 'MIT'
-__all__ = ['convert', 'get_pandoc_formats']
-
 import subprocess
 import sys
 import textwrap
 import os
 import re
+
+__author__ = 'Juho Vepsäläinen'
+__version__ = '0.9.1'
+__license__ = 'MIT'
+__all__ = ['convert', 'get_pandoc_formats']
 
 
 def convert(source, to, format=None, extra_args=(), encoding='utf-8'):


### PR DESCRIPTION
[Travis CI failed](https://travis-ci.org/msabramo/pypandoc/jobs/50084567) with:

```
$ tox
GLOB sdist-make: /home/travis/build/msabramo/pypandoc/setup.py
flake8 create: /home/travis/build/msabramo/pypandoc/.tox/flake8
flake8 installdeps: flake8
flake8 inst: /home/travis/build/msabramo/pypandoc/.tox/dist/pypandoc-0.9.0.zip
flake8 runtests: PYTHONHASHSEED='3837856781'
flake8 runtests: commands[0] | flake8 pypandoc.py tests.py
pypandoc.py:9:1: E402 module level import not at top of file
pypandoc.py:10:1: E402 module level import not at top of file
pypandoc.py:11:1: E402 module level import not at top of file
pypandoc.py:12:1: E402 module level import not at top of file
pypandoc.py:13:1: E402 module level import not at top of file
```