### PR TITLE
Allow Markdown extensions in input format

### DIFF
--- a/pypandoc.py
+++ b/pypandoc.py
@@ -46,15 +46,12 @@ def _convert(reader, processor, source, to,
 
     from_formats, to_formats = get_pandoc_formats()
 
-    if format not in from_formats:
+    if _get_base_format(format) not in from_formats:
         raise RuntimeError(
             'Invalid input format! Expected one of these: ' +
             ', '.join(from_formats))
 
-    # Markdown syntax extensions can be individually enabled or disabled by
-    # appending +EXTENSION or -EXTENSION to the format name.
-    to_base = re.split('\+|-', to)[0]
-    if to_base not in to_formats:
+    if _get_base_format(to) not in to_formats:
         raise RuntimeError(
             'Invalid output format! Expected one of these: ' +
             ', '.join(to_formats))
@@ -91,6 +88,16 @@ def _process_file(source, to, format, extra_args):
         c = p.communicate(source)[0]
 
     return c
+
+
+def _get_base_format(format):
+    '''
+    According to http://johnmacfarlane.net/pandoc/README.html#general-options,
+    syntax extensions for markdown can be individually enabled or disabled by
+    appending +EXTENSION or -EXTENSION to the format name.
+    Return the base format without any extensions.
+    '''
+    return re.split('\+|-', format)[0]
 
 
 def get_pandoc_formats():

--- a/tests.py
+++ b/tests.py
@@ -74,6 +74,15 @@ class TestPypandoc(unittest.TestCase):
         self.assertEqualExceptForNewlineEnd(expected_with_extension, received_with_extension)
         self.assertEqualExceptForNewlineEnd(expected_without_extension, received_without_extension)
 
+    def test_conversion_from_markdown_with_extensions(self):
+        input = u'~~strike~~'
+        expected_with_extension = u'<p><del>strike</del></p>'
+        expected_without_extension = u'<p><sub><sub>strike</sub></sub></p>'
+        received_with_extension = pypandoc.convert(input, 'html', format='markdown+strikeout')
+        received_without_extension = pypandoc.convert(input, 'html', format='markdown-strikeout')
+        self.assertEqualExceptForNewlineEnd(expected_with_extension, received_with_extension)
+        self.assertEqualExceptForNewlineEnd(expected_without_extension, received_without_extension)
+
     def assertEqualExceptForNewlineEnd(self, expected, received):
         self.assertEqual(expected.rstrip('\n'), received.rstrip('\n'))
 


### PR DESCRIPTION
This was added in cb5a70b, but only for the output format. This adds it also for the input format, where pandoc allows the same way of specifying syntax extensions. A basic test is also included.
