### PR TITLE
Support writing output to a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 dist/
 pypandoc.egg-info/
 .tox/
+
+## IDEs
+# pycharm
+.idea/

--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ output = pypandoc.convert('#some title', 'rst', format='md')
 # output == 'some title\r\n==========\r\n\r\n'
 ```
 
+It's also possible to directly let pandoc write the output to a file. This is the only way to 
+convert to some output formats (e.g. odt, docx, epub, epub3). In that case `convert()` will 
+return an empty string.
+
+```python
+import pypandoc
+
+output = pypandoc.convert('somefile.md', 'docx', outputfile="somefile.docx")
+assert output == ""
+```
+
 In addition to `format`, it is possible to pass `extra_args`.
 That makes it possible to access various pandoc options easily.
 
@@ -79,6 +90,7 @@ See [pyandoc](http://pypi.python.org/pypi/pyandoc/) for an alternative implement
 * [Amy Guy](https://github.com/rhiaro) - Exception handling for unicode errors
 * [Florian Eßer](https://github.com/flesser) - Allow Markdown extensions in output format
 * [Philipp Wendler](https://github.com/PhilippWendler) - Allow Markdown extensions in input format
+* [Jan Schulz](https://github.com/JanSchulz) - Handling output to a file
 
 ## License
 

--- a/tests.py
+++ b/tests.py
@@ -97,6 +97,11 @@ class TestPypandoc(unittest.TestCase):
         os.remove(name)
         self.assertEqualExceptForNewlineEnd(expected, written)
 
+        # to odf does not work without a file
+        def f():
+            pypandoc.convert('#some title\n', to='odf', format='md', outputfile=None)
+        self.assertRaises(RuntimeError, f)
+
     def assertEqualExceptForNewlineEnd(self, expected, received):
         # output written to a file does not seem to have os.linesep
         # handle everything here by replacing the os linesep by a simple \n

--- a/tests.py
+++ b/tests.py
@@ -12,7 +12,7 @@ def test_converter(to, format=None, extra_args=()):
     def reader(*args, **kwargs):
         return source, format
 
-    def processor(*args):
+    def processor(*args, **kwargs):
         return 'ok'
 
     source = 'foo'
@@ -83,7 +83,25 @@ class TestPypandoc(unittest.TestCase):
         self.assertEqualExceptForNewlineEnd(expected_with_extension, received_with_extension)
         self.assertEqualExceptForNewlineEnd(expected_without_extension, received_without_extension)
 
+    def test_basic_conversion_to_file(self):
+        # we just want to get a temp file name, where we can write to
+        tf = tempfile.NamedTemporaryFile(suffix='.rst', delete=False)
+        name = tf.name
+        tf.close()
+
+        expected = u'some title{0}=========={0}{0}'.format(os.linesep)
+        received = pypandoc.convert('#some title\n', to='rst', format='md', outputfile=name)
+        self.assertEqualExceptForNewlineEnd("", received)
+        with open(name) as f:
+            written = f.read()
+        os.remove(name)
+        self.assertEqualExceptForNewlineEnd(expected, written)
+
     def assertEqualExceptForNewlineEnd(self, expected, received):
+        # output written to a file does not seem to have os.linesep
+        # handle everything here by replacing the os linesep by a simple \n
+        expected = expected.replace(os.linesep, "\n")
+        received = received.replace(os.linesep, "\n")
         self.assertEqual(expected.rstrip('\n'), received.rstrip('\n'))
 
 


### PR DESCRIPTION
Output writing to a file is needed for some filetypes (e.g. odt, docx).
Closes: #43

Also remove idea/pycharm project files from git