### PR TITLE
Pandoc filter handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ pypandoc provides a thin wrapper for [pandoc](http://johnmacfarlane.net/pandoc/)
   - [FreeBSD port](http://www.freshports.org/textproc/pandoc/)
   - Or see http://johnmacfarlane.net/pandoc/installing.html
 - `pip install pypandoc`
+- To use pandoc filters, you must have the relevant filter installed on your machine
 
 ## Usage
 
@@ -57,6 +58,20 @@ output = pypandoc.convert(
     extra_args=['--base-header-level=2'])
 # output == '<h2 id="primary-heading">Primary Heading</h2>\r\n'
 ```
+pypandoc now supports easy addition of [pandoc filters](http://johnmacfarlane.net/pandoc/scripting.html).
+
+```python
+filters = ['pandoc-citeproc']
+pdoc_args = ['--mathjax',
+             '--smart']
+output = pd.convert(source=filename,
+                    to='html5',
+                    format='md',
+                    extra_args=pdoc_args,
+                    filters=filters)
+```
+Please pass any filters in as a list and not a string.
+
 
 Please refer to `pandoc -h` and the [official documentation](http://johnmacfarlane.net/pandoc/README.html) for further details.
 
@@ -100,6 +115,7 @@ Contributions are welcome. When opening a PR, please keep the following guidelin
 * [Florian Eßer](https://github.com/flesser) - Allow Markdown extensions in output format
 * [Philipp Wendler](https://github.com/PhilippWendler) - Allow Markdown extensions in input format
 * [Jan Schulz](https://github.com/JanSchulz) - Handling output to a file, Travis to work on newer version of Pandoc
+* [Aaron Gonzales](https://github.com/xysmas) - Added better filter handling 
 
 ## License
 

--- a/filter_test.md
+++ b/filter_test.md
@@ -1,0 +1,27 @@
+---
+## This is an in-header citation in bibyaml format
+## Example taken from pandoc website
+references:
+- id: fenner2012a
+  title: One-click science marketing
+  author:
+  - family: Fenner
+    given: Martin
+  container-title: Nature Materials
+  volume: 11
+  URL: 'http://dx.doi.org/10.1038/nmat3283'
+  DOI: 10.1038/nmat3283
+  issue: 4
+  publisher: Nature Publishing Group
+  page: 261-263
+  type: article-journal
+  issued:
+    year: 2012
+    month: 3
+---
+
+## Section ##
+
+A reference [@fenner2012a].
+
+# References

--- a/pypandoc.py
+++ b/pypandoc.py
@@ -94,7 +94,9 @@ def _process_file(source, to, format, extra_args, outputfile=None, filters=None)
     args.extend(extra_args)
 
     # adds the proper filter syntax for each item in the filters list
-    if filters != None:
+    if filters is not None:
+        if type(filters) == str:
+            filters = filters.split()
         f = ['--filter=' + x for x in filters]
         args.extend(f)
 

--- a/pypandoc.py
+++ b/pypandoc.py
@@ -13,11 +13,13 @@ __license__ = 'MIT'
 __all__ = ['convert', 'get_pandoc_formats']
 
 
-def convert(source, to, format=None, extra_args=(), encoding='utf-8', outputfile=None):
+def convert(source, to, format=None, extra_args=(), encoding='utf-8',
+            outputfile=None, filters=None):
     '''Converts given `source` from `format` `to` another. `source` may be
     either a file path or a string to be converted. It's possible to pass
     `extra_args` if needed. In case `format` is not provided, it will try to
-    invert the format based on given `source`.
+    invert the format based on given `source`. Pandoc filters can be passed as
+    a list, e.g. filters=['pandoc-citeproc']
 
     Raises OSError if pandoc is not found! Make sure it has been installed
     and is available at path.
@@ -25,11 +27,11 @@ def convert(source, to, format=None, extra_args=(), encoding='utf-8', outputfile
     '''
     return _convert(_read_file, _process_file, source, to,
                     format, extra_args, encoding=encoding,
-                    outputfile=outputfile)
+                    outputfile=outputfile, filters=filters)
 
 
 def _convert(reader, processor, source, to, format=None, extra_args=(), encoding=None,
-             outputfile=None):
+             outputfile=None, filters=None):
     source, format = reader(source, format, encoding=encoding)
 
     formats = {
@@ -65,7 +67,8 @@ def _convert(reader, processor, source, to, format=None, extra_args=(), encoding
             'Output to %s only works by using a outputfile.' % base_to_format
         )
 
-    return processor(source, to, format, extra_args, outputfile=outputfile)
+    return processor(source, to, format, extra_args, outputfile=outputfile,
+                     filters=filters)
 
 
 def _read_file(source, format, encoding='utf-8'):
@@ -82,13 +85,18 @@ def _read_file(source, format, encoding='utf-8'):
     return source, format
 
 
-def _process_file(source, to, format, extra_args, outputfile=None):
+def _process_file(source, to, format, extra_args, outputfile=None, filters=None):
     args = ['pandoc', '--from=' + format, '--to=' + to]
 
     if outputfile:
         args.append("--output="+outputfile)
 
     args.extend(extra_args)
+
+    # adds the proper filter syntax for each item in the filters list
+    if filters != None:
+        f = ['--filter=' + x for x in filters]
+        args.extend(f)
 
     p = subprocess.Popen(
         args,

--- a/tests.py
+++ b/tests.py
@@ -107,6 +107,17 @@ class TestPypandoc(unittest.TestCase):
                              outputfile=None)
         self.assertRaises(RuntimeError, f)
 
+    def test_basic_conversion_with_filter(self):
+        # we just want to get a temp file name, where we can write to
+        filters = ['pandoc-citeproc']
+        written = pypandoc.convert('./filter_test.md', to='html', format='md',
+                                   outputfile=None, filters=filters)
+        import re as re
+        found = re.search(r'Fenner', written)
+        self.assertTrue(found.group() == 'Fenner')
+        found = re.search(r'10.1038', written)
+        self.assertTrue(found.group() == '10.1038')
+
     def assertEqualExceptForNewlineEnd(self, expected, received):
         # output written to a file does not seem to have os.linesep
         # handle everything here by replacing the os linesep by a simple \n

--- a/tests.py
+++ b/tests.py
@@ -107,16 +107,31 @@ class TestPypandoc(unittest.TestCase):
                              outputfile=None)
         self.assertRaises(RuntimeError, f)
 
-    def test_basic_conversion_with_filter(self):
+    def test_conversion_with_citeproc_filter(self):
         # we just want to get a temp file name, where we can write to
         filters = ['pandoc-citeproc']
         written = pypandoc.convert('./filter_test.md', to='html', format='md',
                                    outputfile=None, filters=filters)
         import re as re
+        # only properly converted file will have this in it
         found = re.search(r'Fenner', written)
         self.assertTrue(found.group() == 'Fenner')
+        # only properly converted file will have this in it
         found = re.search(r'10.1038', written)
         self.assertTrue(found.group() == '10.1038')
+
+    def test_conversion_with_empty_filter(self):
+        # we just want to get a temp file name, where we can write to
+        filters = ''
+        written = pypandoc.convert('./filter_test.md', to='html', format='md',
+                                   outputfile=None, filters=filters)
+        import re as re
+        # This should not use the pandoc-citeproc module and will not find the
+        # strings
+        found = re.search(r'Fenner', written)
+        self.assertTrue(found is None)
+        found = re.search(r'10.1038', written)
+        self.assertTrue(found is None)
 
     def assertEqualExceptForNewlineEnd(self, expected, received):
         # output written to a file does not seem to have os.linesep


### PR DESCRIPTION
Fixes #47 by adding support for passing a list of filters ,e.g.

```python
filters = ['pandoc-citeproc']
pdoc_args = ['--mathjax',
             '--smart']
output = pd.convert(source=filename,
                    to='html5',
                    format='md',
                    extra_args=pdoc_args,
                    filters=filters)
```
Passes flake8, made new tests, etc. 