### PR TITLE
Check return code and some unicode handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![Latest Version](https://pypip.in/version/pypandoc/badge.svg)](https://pypi.python.org/pypi/pypandoc/)
 [![Build Status](https://travis-ci.org/bebraw/pypandoc.svg?branch=master)](https://travis-ci.org/bebraw/pypandoc)
 
-pypandoc provides a thin wrapper for [pandoc](http://johnmacfarlane.net/pandoc/), a universal document converter.
+pypandoc provides a thin wrapper for [pandoc](http://johnmacfarlane.net/pandoc/), a universal 
+document converter.
 
 ## Installation
 
@@ -12,7 +13,8 @@ pypandoc provides a thin wrapper for [pandoc](http://johnmacfarlane.net/pandoc/)
   - Fedora/Red Hat: `sudo yum install pandoc`
   - Mac OS X with Homebrew: `brew install pandoc`
   - Machine with Haskell: `cabal-install pandoc`
-  - Windows: There is an installer available [here](http://johnmacfarlane.net/pandoc/installing.html)
+  - Windows: There is an installer available 
+    [here](http://johnmacfarlane.net/pandoc/installing.html)
   - [FreeBSD port](http://www.freshports.org/textproc/pandoc/)
   - Or see http://johnmacfarlane.net/pandoc/installing.html
 - `pip install pypandoc`
@@ -20,7 +22,10 @@ pypandoc provides a thin wrapper for [pandoc](http://johnmacfarlane.net/pandoc/)
 
 ## Usage
 
-The basic invocation looks like this: `pypandoc.convert('input', 'output format')`. `pypandoc` tries to infer the type of the input automatically. If it's a file, it will load it. In case you pass a string, you can define the `format` using the parameter. The example below should clarify the usage:
+The basic invocation looks like this: `pypandoc.convert('input', 'output format')`. `pypandoc` 
+tries to infer the type of the input automatically. If it's a file, it will load it. In case you 
+pass a string, you can define the `format` using the parameter. The example below should clarify
+the usage:
 
 ```python
 import pypandoc
@@ -31,6 +36,9 @@ output = pypandoc.convert('somefile.md', 'rst')
 output = pypandoc.convert('#some title', 'rst', format='md')
 # output == 'some title\r\n==========\r\n\r\n'
 ```
+
+If you pass in a string (and not a filename), `convert` expects this string to be unicode or 
+utf-8 encoded bytes. `convert` will always return a unicode string.
 
 It's also possible to directly let pandoc write the output to a file. This is the only way to 
 convert to some output formats (e.g. odt, docx, epub, epub3). In that case `convert()` will 
@@ -58,7 +66,8 @@ output = pypandoc.convert(
     extra_args=['--base-header-level=2'])
 # output == '<h2 id="primary-heading">Primary Heading</h2>\r\n'
 ```
-pypandoc now supports easy addition of [pandoc filters](http://johnmacfarlane.net/pandoc/scripting.html).
+pypandoc now supports easy addition of 
+[pandoc filters](http://johnmacfarlane.net/pandoc/scripting.html).
 
 ```python
 filters = ['pandoc-citeproc']
@@ -73,11 +82,15 @@ output = pd.convert(source=filename,
 Please pass any filters in as a list and not a string.
 
 
-Please refer to `pandoc -h` and the [official documentation](http://johnmacfarlane.net/pandoc/README.html) for further details.
+Please refer to `pandoc -h` and the 
+[official documentation](http://johnmacfarlane.net/pandoc/README.html) for further details.
 
 ## Related
 
-[pydocverter](https://github.com/msabramo/pydocverter) is a client for a service called [Docverter](http://www.docverter.com/), which offers pandoc as a service (plus some extra goodies). It has the same API as pypandoc, so you can easily write code that uses one and falls back to the other. E.g.:
+[pydocverter](https://github.com/msabramo/pydocverter) is a client for a service called 
+[Docverter](http://www.docverter.com/), which offers pandoc as a service (plus some extra goodies). 
+It has the same API as pypandoc, so you can easily write code that uses one and falls back to the 
+other. E.g.:
 
 ```python
 try:
@@ -88,7 +101,8 @@ except ImportError:
 converter.convert('somefile.md', 'rst')
 ```
 
-See [pyandoc](http://pypi.python.org/pypi/pyandoc/) for an alternative implementation of a pandoc wrapper from Kenneth Reitz. This one hasn't been active in a while though.
+See [pyandoc](http://pypi.python.org/pypi/pyandoc/) for an alternative implementation of a pandoc 
+wrapper from Kenneth Reitz. This one hasn't been active in a while though.
 
 ## Contributing
 
@@ -97,7 +111,8 @@ Contributions are welcome. When opening a PR, please keep the following guidelin
 1. Before implementing, please open an issue for discussion.
 2. Make sure you have tests for the new logic.
 3. Make sure your code passes `flake8 pypandoc.py tests.py`
-4. Add yourself to contributors at `README.md` unless you are already there. In that case tweak your contributions.
+4. Add yourself to contributors at `README.md` unless you are already there. In that case tweak 
+   your contributions.
 
 ## Contributors
 
@@ -105,16 +120,20 @@ Contributions are welcome. When opening a PR, please keep the following guidelin
 * [Daniel Sanchez](https://github.com/ErunamoJAZZ) - Automatic parsing of input/output formats
 * [Thomas G.](https://github.com/coldfix) - Python 3 support
 * [Ben Jao Ming](https://github.com/benjaoming) - Fail gracefully if `pandoc` is missing
-* [Ross Crawford-d'Heureuse](http://github.com/rosscdh) - Encode input in UTF-8 and add Django example
+* [Ross Crawford-d'Heureuse](http://github.com/rosscdh) - Encode input in UTF-8 and add Django 
+  example
 * [Michael Chow](https://github.com/machow) - Decode output in UTF-8
-* [Janusz Skonieczny](https://github.com/wooyek) - Support Windows newlines and allow encoding to be specified.
+* [Janusz Skonieczny](https://github.com/wooyek) - Support Windows newlines and allow encoding to 
+  be specified.
 * [gabeos](https://github.com/gabeos) - Fix help parsing
-* [Marc Abramowitz](https://github.com/msabramo) - Make `setup.py` fail hard if `pandoc` is missing, Travis, Dockerfile, PyPI badge, Tox, PEP-8, improved documentation
+* [Marc Abramowitz](https://github.com/msabramo) - Make `setup.py` fail hard if `pandoc` is 
+  missing, Travis, Dockerfile, PyPI badge, Tox, PEP-8, improved documentation
 * [Daniel L.](https://github.com/mcktrtl) - Add `extra_args` example to README
 * [Amy Guy](https://github.com/rhiaro) - Exception handling for unicode errors
 * [Florian Eßer](https://github.com/flesser) - Allow Markdown extensions in output format
 * [Philipp Wendler](https://github.com/PhilippWendler) - Allow Markdown extensions in input format
-* [Jan Schulz](https://github.com/JanSchulz) - Handling output to a file, Travis to work on newer version of Pandoc
+* [Jan Schulz](https://github.com/JanSchulz) - Handling output to a file, Travis to work on newer 
+  version of Pandoc, return code checking
 * [Aaron Gonzales](https://github.com/xysmas) - Added better filter handling 
 
 ## License

--- a/pypandoc.py
+++ b/pypandoc.py
@@ -123,10 +123,18 @@ def _process_file(source, to, format, extra_args, outputfile=None, filters=None)
         )
 
     try:
-        stdout, stderr = p.communicate(source.encode('utf-8'))
-        stdout = stdout.decode('utf-8')
+        source = source.encode('utf-8')
     except (UnicodeDecodeError, UnicodeEncodeError):
-        stdout, stderr = p.communicate(source)
+        # assume that it is already a utf-8 encoded string
+        pass
+
+    stdout, stderr = p.communicate(source)
+
+    try:
+        stdout = stdout.decode('utf-8')
+    except UnicodeDecodeError:
+        # this shouldn't happen: pandoc more or less garantees that the output is utf-8!
+        raise RuntimeError('Pandoc output was not utf-8.')
 
     # check that pandoc returned successfully
     if p.returncode != 0:

--- a/pypandoc.py
+++ b/pypandoc.py
@@ -13,6 +13,15 @@ __license__ = 'MIT'
 __all__ = ['convert', 'get_pandoc_formats']
 
 
+if sys.version_info[0] >= 3:
+    PY3 = True
+    string_types = (str,)
+    unicode_type = str
+else:
+    PY3 = False
+    string_types = (str, unicode)
+    unicode_type = unicode
+
 def convert(source, to, format=None, extra_args=(), encoding='utf-8',
             outputfile=None, filters=None):
     '''Converts given `source` from `format` `to` another. `source` may be
@@ -95,7 +104,7 @@ def _process_file(source, to, format, extra_args, outputfile=None, filters=None)
 
     # adds the proper filter syntax for each item in the filters list
     if filters is not None:
-        if type(filters) == str:
+        if isinstance(filters, string_types):
             filters = filters.split()
         f = ['--filter=' + x for x in filters]
         args.extend(f)

--- a/pypandoc.py
+++ b/pypandoc.py
@@ -26,29 +26,30 @@ def convert(source, to, format=None, extra_args=(), encoding='utf-8',
             outputfile=None, filters=None):
     """Converts given `source` from `format` `to` another.
 
-    :param str source: Unicode string or utf-8 encoded bytes or a file path
+    :param str source: Unicode string or bytes or a file path (see encoding)
 
-    :param str to: format into which the input should be converted. Can be one of
+    :param str to: format into which the input should be converted; can be one of
             `pypandoc.get_pandoc_formats()[1]`
 
     :param str format: the format of the inputs; will be inferred if input is a file with an
-            known filename extension (Default value = None)
+            known filename extension; can be one of `pypandoc.get_pandoc_formats()[1]`
+            (Default value = None)
 
     :param list extra_args: extra arguments (list of strings) to be passed to pandoc
             (Default value = ())
 
-    :param str encoding: the encoding of the file (Default value = 'utf-8')
+    :param str encoding: the encoding of the file or the input bytes (Default value = 'utf-8')
 
-    :param str outputfile: Output will be written to outfilename or the converted content
+    :param str outputfile: output will be written to outfilename or the converted content
             returned if None (Default value = None)
 
-    :param list filters: Pandoc filters e.g. filters=['pandoc-citeproc']
+    :param list filters: pandoc filters e.g. filters=['pandoc-citeproc']
 
     :returns: converted string (unicode) or an empty string if an outputfile was given
     :rtype: unicode
 
     :raises RuntimeError: if any of the inputs are not valid of if pandoc fails with an error
-    :raises OSError: if pandoc is not found! Make sure it has been installed and is available at
+    :raises OSError: if pandoc is not found; make sure it has been installed and is available at
             path.
     """
     return _convert(_read_file, _process_file, source, to,

--- a/pypandoc.py
+++ b/pypandoc.py
@@ -107,7 +107,14 @@ def _read_file(source, format, encoding='utf-8'):
         with codecs.open(source, encoding=encoding) as f:
             format = format or os.path.splitext(source)[1].strip('.')
             source = f.read()
-
+    else:
+        if encoding != 'utf-8':
+            # if a source and a different encoding is given, try to decode the the source into a
+            # unicode string
+            try:
+                source = source.decode(encoding)
+            except (UnicodeDecodeError, UnicodeEncodeError):
+                pass
     return source, format
 
 

--- a/pypandoc.py
+++ b/pypandoc.py
@@ -28,6 +28,7 @@ def _decode(s, encoding=None):
     encoding = encoding or _DEFAULT_ENCODING
     return s.decode(encoding)
 
+
 def _encode(u, encoding=None):
     encoding = encoding or _DEFAULT_ENCODING
     return u.encode(encoding)
@@ -38,11 +39,13 @@ def _cast_unicode(s, encoding=None):
         return _decode(s, encoding)
     return s
 
+
 def _cast_bytes(s, encoding=None):
     # bytes == str on py2.7 -> always encode on py2
     if not isinstance(s, bytes):
         return _encode(s, encoding)
     return s
+
 
 if sys.version_info[0] >= 3:
     PY3 = True
@@ -54,6 +57,7 @@ else:
 
     string_types = (str, unicode)
     unicode_type = unicode
+
 
 def convert(source, to, format=None, extra_args=(), encoding='utf-8',
             outputfile=None, filters=None):
@@ -174,7 +178,7 @@ def _process_file(source, to, format, extra_args, outputfile=None, filters=None)
         stderr=subprocess.PIPE)
 
     # something else than 'None' indicates that the process already terminated
-    if not p.returncode is None:
+    if not (p.returncode is None):
         raise RuntimeError(
             'Pandoc died with exitcode "%s" before receiving input: %s' % (p.returncode,
                                                                            p.stderr.read())

--- a/pypandoc.py
+++ b/pypandoc.py
@@ -24,16 +24,33 @@ else:
 
 def convert(source, to, format=None, extra_args=(), encoding='utf-8',
             outputfile=None, filters=None):
-    '''Converts given `source` from `format` `to` another. `source` may be
-    either a file path or a string to be converted. It's possible to pass
-    `extra_args` if needed. In case `format` is not provided, it will try to
-    invert the format based on given `source`. Pandoc filters can be passed as
-    a list, e.g. filters=['pandoc-citeproc']
+    """Converts given `source` from `format` `to` another.
 
-    Raises OSError if pandoc is not found! Make sure it has been installed
-    and is available at path.
+    :param str source: Unicode string or utf-8 encoded bytes or a file path
 
-    '''
+    :param str to: format into which the input should be converted. Can be one of
+            `pypandoc.get_pandoc_formats()[1]`
+
+    :param str format: the format of the inputs; will be inferred if input is a file with an
+            known filename extension (Default value = None)
+
+    :param list extra_args: extra arguments (list of strings) to be passed to pandoc
+            (Default value = ())
+
+    :param str encoding: the encoding of the file (Default value = 'utf-8')
+
+    :param str outputfile: Output will be written to outfilename or the converted content
+            returned if None (Default value = None)
+
+    :param list filters: Pandoc filters e.g. filters=['pandoc-citeproc']
+
+    :returns: converted string (unicode) or an empty string if an outputfile was given
+    :rtype: unicode
+
+    :raises RuntimeError: if any of the inputs are not valid of if pandoc fails with an error
+    :raises OSError: if pandoc is not found! Make sure it has been installed and is available at
+            path.
+    """
     return _convert(_read_file, _process_file, source, to,
                     format, extra_args, encoding=encoding,
                     outputfile=outputfile, filters=filters)

--- a/tests.py
+++ b/tests.py
@@ -120,6 +120,17 @@ class TestPypandoc(unittest.TestCase):
         found = re.search(r'10.1038', written)
         self.assertTrue(found.group() == '10.1038')
 
+        # make sure that it splits the filter line
+        for filters in ['pandoc-citeproc', u'pandoc-citeproc']:
+            written = pypandoc.convert('./filter_test.md', to='html', format='md',
+                                       outputfile=None, filters=filters)
+            # only properly converted file will have this in it
+            found = re.search(r'Fenner', written)
+            self.assertTrue(found.group() == 'Fenner')
+            # only properly converted file will have this in it
+            found = re.search(r'10.1038', written)
+            self.assertTrue(found.group() == '10.1038')
+
     def test_conversion_with_empty_filter(self):
         # we just want to get a temp file name, where we can write to
         filters = ''

--- a/tests.py
+++ b/tests.py
@@ -162,10 +162,22 @@ class TestPypandoc(unittest.TestCase):
         written = pypandoc.convert(bytes,'md', format='html')
         self.assertEqualExceptForNewlineEnd(expected, written)
         self.assertTrue(isinstance(written, pypandoc.unicode_type))
+
+        # Only use german umlauts in th next test, as iso-8859-15 covers that
+        expected = u'üäö€{0}===={0}{0}'.format(os.linesep)
+        bytes = u'<h1>üäö€</h1>'.encode("iso-8859-15")
+        # Without encoding, this fails as we expect utf-8 per default
         def f():
-            bytes = u'<h1>üäö</h1>'.encode("iso-8859-15")
             nothing = pypandoc.convert(bytes,'md', format='html')
         self.assertRaises(RuntimeError, f)
+        def f():
+            # we have to use something which interprets '\xa4', so latin and -1 does not work :-/
+            nothing = pypandoc.convert(bytes,'md', format='html', encoding="utf-16")
+        self.assertRaises(RuntimeError, f)
+        # with the right encoding it should work...
+        written = pypandoc.convert(bytes,'md', format='html', encoding="iso-8859-15")
+        self.assertEqualExceptForNewlineEnd(expected, written)
+        self.assertTrue(isinstance(written, pypandoc.unicode_type))
 
     def assertEqualExceptForNewlineEnd(self, expected, received):
         # output written to a file does not seem to have os.linesep

--- a/tests.py
+++ b/tests.py
@@ -148,18 +148,17 @@ class TestPypandoc(unittest.TestCase):
     def test_conversion_error(self):
         # pandoc dies on wrong commandline arguments
         def f():
-            pypandoc.convert('<h1>Primary Heading</h1>','md', format='html', extra_args=["--blah"])
+            pypandoc.convert('<h1>Primary Heading</h1>', 'md', format='html', extra_args=["--blah"])
         self.assertRaises(RuntimeError, f)
-
 
     def test_unicode_input(self):
         # make sure that pandoc always returns unicode and does not mishandle it
         expected = u'üäöîôû{0}======{0}{0}'.format(os.linesep)
-        written = pypandoc.convert(u'<h1>üäöîôû</h1>','md', format='html')
+        written = pypandoc.convert(u'<h1>üäöîôû</h1>', 'md', format='html')
         self.assertTrue(isinstance(written, pypandoc.unicode_type))
         self.assertEqualExceptForNewlineEnd(expected, written)
         bytes = u'<h1>üäöîôû</h1>'.encode("utf-8")
-        written = pypandoc.convert(bytes,'md', format='html')
+        written = pypandoc.convert(bytes, 'md', format='html')
         self.assertEqualExceptForNewlineEnd(expected, written)
         self.assertTrue(isinstance(written, pypandoc.unicode_type))
 
@@ -167,15 +166,17 @@ class TestPypandoc(unittest.TestCase):
         expected = u'üäö€{0}===={0}{0}'.format(os.linesep)
         bytes = u'<h1>üäö€</h1>'.encode("iso-8859-15")
         # Without encoding, this fails as we expect utf-8 per default
+
         def f():
-            nothing = pypandoc.convert(bytes,'md', format='html')
+            pypandoc.convert(bytes, 'md', format='html')
         self.assertRaises(RuntimeError, f)
+
         def f():
             # we have to use something which interprets '\xa4', so latin and -1 does not work :-/
-            nothing = pypandoc.convert(bytes,'md', format='html', encoding="utf-16")
+            pypandoc.convert(bytes, 'md', format='html', encoding="utf-16")
         self.assertRaises(RuntimeError, f)
         # with the right encoding it should work...
-        written = pypandoc.convert(bytes,'md', format='html', encoding="iso-8859-15")
+        written = pypandoc.convert(bytes, 'md', format='html', encoding="iso-8859-15")
         self.assertEqualExceptForNewlineEnd(expected, written)
         self.assertTrue(isinstance(written, pypandoc.unicode_type))
 

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 import unittest
 import tempfile
@@ -150,6 +151,21 @@ class TestPypandoc(unittest.TestCase):
             pypandoc.convert('<h1>Primary Heading</h1>','md', format='html', extra_args=["--blah"])
         self.assertRaises(RuntimeError, f)
 
+
+    def test_unicode_input(self):
+        # make sure that pandoc always returns unicode and does not mishandle it
+        expected = u'üäöîôû{0}======{0}{0}'.format(os.linesep)
+        written = pypandoc.convert(u'<h1>üäöîôû</h1>','md', format='html')
+        self.assertTrue(isinstance(written, pypandoc.unicode_type))
+        self.assertEqualExceptForNewlineEnd(expected, written)
+        bytes = u'<h1>üäöîôû</h1>'.encode("utf-8")
+        written = pypandoc.convert(bytes,'md', format='html')
+        self.assertEqualExceptForNewlineEnd(expected, written)
+        self.assertTrue(isinstance(written, pypandoc.unicode_type))
+        def f():
+            bytes = u'<h1>üäö</h1>'.encode("iso-8859-15")
+            nothing = pypandoc.convert(bytes,'md', format='html')
+        self.assertRaises(RuntimeError, f)
 
     def assertEqualExceptForNewlineEnd(self, expected, received):
         # output written to a file does not seem to have os.linesep

--- a/tests.py
+++ b/tests.py
@@ -133,6 +133,13 @@ class TestPypandoc(unittest.TestCase):
         found = re.search(r'10.1038', written)
         self.assertTrue(found is None)
 
+    def test_conversion_error(self):
+        # pandoc dies on wrong commandline arguments
+        def f():
+            pypandoc.convert('<h1>Primary Heading</h1>','md', format='html', extra_args=["--blah"])
+        self.assertRaises(RuntimeError, f)
+
+
     def assertEqualExceptForNewlineEnd(self, expected, received):
         # output written to a file does not seem to have os.linesep
         # handle everything here by replacing the os linesep by a simple \n


### PR DESCRIPTION
Check the return code of the pandoc call, so that we can raise if there was an error

Closes: #49

Also make sure that we handle unicode in filters-as-a-string and encoded strings and make sure that we always return unicode.