### PR TITLE
Fix Travis errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
-sudo: required
+sudo: false
 env:
-  global:
-    - CI=1
   matrix:
     - TOXENV=py26
     - TOXENV=py27
@@ -10,18 +8,23 @@ env:
     - TOXENV=py34
     - TOXENV=pypy
     - TOXENV=flake8
-services:
-  - docker
 addons:
-  apt_packages:
-    - pandoc
-    - pandoc-citeproc
-    - texlive-latex-base
-    - texlive-latex-extra
-    - texlive-fonts-recommended
-    - lmodern
+  apt:
+    packages:
+      - texlive-latex-base
+      - texlive-latex-extra
+      - texlive-fonts-recommended
+      - lmodern
 install:
+  - "[ ! -d ~/bin ] && mkdir ~/bin || true"
+  # Stolen from https://github.com/yihui/knitr/blob/master/.travis.yml
+  - "wget -q -O - https://github.com/yihui/crandalf/raw/master/inst/scripts/install-pandoc | bash"
   - travis_retry pip install tox
+
+cache:
+  directories:
+  - $HOME/bin
+
 script:
   - pandoc -v
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,11 @@ addons:
       - texlive-latex-base
       - texlive-latex-extra
       - texlive-fonts-recommended
+      - texlive-latex-recommended
       - lmodern
 install:
-  - "[ ! -d ~/bin ] && mkdir ~/bin || true"
   # Stolen from https://github.com/yihui/knitr/blob/master/.travis.yml
+  - "[ ! -d ~/bin ] && mkdir ~/bin || true"
   - "wget -q -O - https://github.com/yihui/crandalf/raw/master/inst/scripts/install-pandoc | bash"
   - travis_retry pip install tox
 

--- a/pypandoc.py
+++ b/pypandoc.py
@@ -199,8 +199,12 @@ def _process_file(source, input_type, to, format, extra_args, outputfile=None,
     except (UnicodeDecodeError, UnicodeEncodeError):
         # assume that it is already a utf-8 encoded string
         pass
-
-    stdout, stderr = p.communicate(source if string_input else None)
+    try:
+        stdout, stderr = p.communicate(source if string_input else None)
+    except OSError:
+        # this is happening only on Py2.6 when pandoc dies before reading all
+        # the input. We treat that the same as when we exit with an error...
+        raise RuntimeError('Pandoc died with exitcode "%s" during conversion.' % (p.returncode))
 
     try:
         stdout = stdout.decode('utf-8')

--- a/tests.py
+++ b/tests.py
@@ -24,6 +24,18 @@ def test_converter(to, format=None, extra_args=()):
 
 class TestPypandoc(unittest.TestCase):
 
+    def setUp(self):
+        if 'HOME' not in os.environ:
+            # if this is used with older versions of pandoc-citeproc
+            # https://github.com/jgm/pandoc-citeproc/issues/35
+            if 'TRAVIS_BUILD_DIR' in os.environ:
+                os.environ["HOME"] = os.environ["TRAVIS_BUILD_DIR"]
+                print("Using TRAVIS_BUILD_DIR as HOME")
+            else:
+                os.environ["HOME"] = str(os.getcwd())
+                print("Using current dir as HOME")
+        print(os.environ["HOME"])
+
     def test_get_pandoc_formats(self):
         inputs, outputs = pypandoc.get_pandoc_formats()
         self.assertTrue("markdown" in inputs)
@@ -31,10 +43,7 @@ class TestPypandoc(unittest.TestCase):
         self.assertTrue("markdown" in outputs)
 
     def test_get_pandoc_version(self):
-        if os.environ.get('CI', None):
-            print("Skipping: travis fails with 'getAppUserDataDirectory: does not exist'")
-            return
-
+        assert "HOME" in os.environ, "No HOME set, this will error..."
         version = pypandoc.get_pandoc_version()
         self.assertTrue(isinstance(version, pypandoc.string_types))
         major = int(version.split(".")[0])
@@ -208,7 +217,7 @@ class TestPypandoc(unittest.TestCase):
         self.assertTrue(isinstance(written, pypandoc.unicode_type))
 
     def test_conversion_from_non_plain_text_file(self):
-        if os.environ.get('CI', None):
+        if 'CI' in os.environ:
             print("Skipping: travis is running on old pandoc, no docx")
             return
 


### PR DESCRIPTION
* use the same pandoc and pandoc-citeproc as knitr
* add more informative error messages
* update to newer travis infrastructure
* add an additional latex dependency 
* Fix for an error on py2.6. On 2.7+, the implementation of subprocess changed so that this error didn't happen...

Closes: https://github.com/bebraw/pypandoc/issues/55

CC: @rossant 