### PR TITLE
don't require pandoc to install pypandoc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,11 @@
 import pypandoc
 from setuptools import setup
 
-long_description = pypandoc.convert('README.md', 'rst')
+try:
+    long_description = pypandoc.convert('README.md', 'rst')
+except OSError:
+    # pandoc is not installed, fallback to using raw contents
+    long_description = open('README.md').read()
 
 module = pypandoc
 setup(


### PR DESCRIPTION
This changes closes #70 by allowing for pypandoc to install
without pandoc being present on the system.  This allows for
the library to be installed but for clients to handle the
fact that pandoc is not installed in their applications at
runtime.

If pandoc is not present during installation, the warning
from pypandoc is still printed informing users how pandoc
can be installed.

Signed-off-by: Paul Osborne <osbpau@gmail.com>