### PR TITLE
Expose pandoc path

### DIFF
--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -12,7 +12,7 @@ from .py3compat import string_types, cast_bytes, cast_unicode
 __author__ = u'Juho Vepsäläinen'
 __version__ = '1.1.0'
 __license__ = 'MIT'
-__all__ = ['convert', 'get_pandoc_formats', 'get_pandoc_version']
+__all__ = ['convert', 'get_pandoc_formats', 'get_pandoc_version', 'get_pandoc_path']
 
 
 def convert(source, to, format=None, extra_args=(), encoding='utf-8',
@@ -251,6 +251,26 @@ def get_pandoc_version():
         _ensure_pandoc_path()
         __version = _get_pandoc_version(__pandoc_path)
     return __version
+
+
+def get_pandoc_path():
+    """Gets the Pandoc path if Pandoc is installed.
+
+    It will return a path to pandoc which is used by pypandoc.
+
+    This might be a full path or, if pandoc is on PATH, simple `pandoc`. It's garanteed
+    to be callable (i.e. we could get version information from `pandoc --version`).
+    If `PYPANDOC_PANDOC` is set and valid, it will return that value. If the environment
+    variable is not set, either the full path to the included pandoc or the pandoc in
+    `PATH` (whatever is the higher version) will be returned.
+
+    If a cached path is found, it will return the cached path and stop probing Pandoc
+    (unless :func:`clean_pandocpath_cache()` is called).
+
+    :raises OSError: if pandoc is not found
+    """
+    _ensure_pandoc_path()
+    return __pandoc_path
 
 
 def _ensure_pandoc_path():

--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -313,8 +313,8 @@ def _ensure_pandoc_path():
                 ---------------------------------------------------------------
 
             """))
-            raise RuntimeError("No pandoc was found: either install pandoc and add it\n"
-                               "to your PATH or install pypandoc wheels with included pandoc.")
+            raise OSError("No pandoc was found: either install pandoc and add it\n"
+                          "to your PATH or install pypandoc wheels with included pandoc.")
 
 
 # -----------------------------------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ except ImportError:
 
 try:
     long_description = pypandoc.convert('README.md', 'rst')
-except RuntimeError:
+except OSError:
+    print("\n\n!!! pandoc not found, long_description is bad, don't upload this to PyPI !!!\n\n")
     import io
     # pandoc is not installed, fallback to using raw contents
     with io.open('README.md', encoding="utf-8") as f:

--- a/tests.py
+++ b/tests.py
@@ -260,6 +260,10 @@ class TestPypandoc(unittest.TestCase):
         finally:
             os.remove(name)
 
+    def test_get_pandoc_path(self):
+        result = pypandoc.get_pandoc_path()
+        assert "pandoc" in result
+
     def assertEqualExceptForNewlineEnd(self, expected, received):
         # output written to a file does not seem to have os.linesep
         # handle everything here by replacing the os linesep by a simple \n


### PR DESCRIPTION
This switches back to use `OSError` if pandoc is not found (was briefly `RuntimeError`, which could be considered a API breakage :-() and exposes the computed pandoc path as an API call.