### PR TITLE
Overhaul pandoc handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: python
 sudo: false
+python:
+ - 3.5 # otherwise we can't run tox 3.5 tests
 env:
   matrix:
     - TOXENV=py26
     - TOXENV=py27
     - TOXENV=py33
     - TOXENV=py34
+    - TOXENV=py35
     - TOXENV=pypy
     - TOXENV=flake8
 addons:
@@ -24,7 +27,4 @@ install:
 
 script:
   - ./pypandoc/files/pandoc -v
-  - python -c "import pypandoc; print(pypandoc.get_pandoc_version())"
-  # make sure we use our own pandoc version
-  - python -c "import sys; import pypandoc; from pypandoc.pandoc_download import INCLUDED_PANDOC_VERSION as IPV; pypandoc.get_pandoc_version() == IPV or sys.exit(-1)"
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,21 +11,20 @@ env:
 addons:
   apt:
     packages:
+      # Some tests do a pdf conversion, so install latex which is needed for that.
       - texlive-latex-base
       - texlive-latex-extra
       - texlive-fonts-recommended
       - texlive-latex-recommended
       - lmodern
 install:
-  # Stolen from https://github.com/yihui/knitr/blob/master/.travis.yml
-  - "[ ! -d ~/bin ] && mkdir ~/bin || true"
-  - "wget -q -O - https://github.com/yihui/crandalf/raw/master/inst/scripts/install-pandoc | bash"
   - travis_retry pip install tox
-
-cache:
-  directories:
-  - $HOME/bin
+  # only download pandoc, the tests should work without a install of pypandoc
+  - python setup.py download_pandoc
 
 script:
-  - pandoc -v
+  - ./pypandoc/files/pandoc -v
+  - python -c "import pypandoc; print(pypandoc.get_pandoc_version())"
+  # make sure we use our own pandoc version
+  - python -c "import sys; import pypandoc; from pypandoc.pandoc_download import INCLUDED_PANDOC_VERSION as IPV; pypandoc.get_pandoc_version() == IPV or sys.exit(-1)"
   - tox

--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -141,11 +141,18 @@ def _process_file(source, input_type, to, format, extra_args, outputfile=None,
         f = ['--filter=' + x for x in filters]
         args.extend(f)
 
+    # To get access to pandoc-citeproc when we use a included copy of pandoc,
+    # we need to add the pypandoc/files dir to the PATH
+    new_env = os.environ.copy()
+    files_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "files")
+    new_env["PATH"] = new_env.get("PATH", "") + os.pathsep + files_path
+
     p = subprocess.Popen(
         args,
         stdin=subprocess.PIPE if string_input else None,
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE)
+        stderr=subprocess.PIPE,
+        env=new_env)
 
     # something else than 'None' indicates that the process already terminated
     if not (p.returncode is None):
@@ -315,7 +322,7 @@ def _ensure_pandoc_path():
             # print("Trying: %s" % path)
             try:
                 version_string = _get_pandoc_version(path)
-            except Exception as e:
+            except:  # Exception as e:
                 # we can't use that path...
                 # print(e)
                 continue

--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -312,9 +312,10 @@ def _ensure_pandoc_path():
             path = os.path.expanduser(path)
             curr_version = [0, 0, 0]
             version_string = "0.0.0"
+            # print("Trying: %s" % path)
             try:
                 version_string = _get_pandoc_version(path)
-            except:
+            except Exception as e:
                 # we can't use that path...
                 # print(e)
                 continue

--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import with_statement, absolute_import
+from __future__ import with_statement, absolute_import, print_function
 
 import subprocess
 import sys
@@ -322,9 +322,12 @@ def _ensure_pandoc_path():
             # print("Trying: %s" % path)
             try:
                 version_string = _get_pandoc_version(path)
-            except:  # Exception as e:
+            except Exception as e:
                 # we can't use that path...
-                # print(e)
+                if os.path.exists(path):
+                    # path exist but is not useable -> not executable?
+                    print("Found %s, but not using it because of an error:" % (path), file=sys.stderr)
+                    print(e, file=sys.stderr)
                 continue
             version = [int(x) for x in version_string.split(".")]
             while len(version) < len(curr_version):

--- a/pypandoc/pandoc_download.py
+++ b/pypandoc/pandoc_download.py
@@ -22,7 +22,8 @@ PANDOC_URLS = {
     "linux": "https://github.com/jgm/pandoc/releases/download/1.16.0.2/pandoc-1.16.0.2-1-amd64.deb",
     "darwin": "https://github.com/jgm/pandoc/releases/download/1.16.0.2/pandoc-1.16.0.2-osx.pkg"
 }
-INCLUDED_PANDOC_VERSION="1.16.0.2"
+
+INCLUDED_PANDOC_VERSION = "1.16.0.2"
 
 DEFAULT_TARGET_FOLDER = {
     "win32": "~\\AppData\\Local\\Pandoc",
@@ -34,7 +35,9 @@ DEFAULT_TARGET_FOLDER = {
 def _make_executable(path):
     mode = os.stat(path).st_mode
     mode |= (mode & 0o444) >> 2    # copy R bits to X
+    print("* Making %s executeable..." % (path))
     os.chmod(path, mode)
+
 
 def _handle_linux(filename, targetfolder):
 

--- a/pypandoc/pandoc_download.py
+++ b/pypandoc/pandoc_download.py
@@ -18,9 +18,9 @@ except ImportError:
 # Adding a new platform means implementing unpacking in "DownloadPandocCommand"
 # and adding the URL here
 PANDOC_URLS = {
-    "win32": "https://github.com/jgm/pandoc/releases/download/1.15.1.1/pandoc-1.15.1.1-windows.msi",
-    "linux": "https://github.com/jgm/pandoc/releases/download/1.15.1/pandoc-1.15.1-1-amd64.deb",
-    "darwin": "https://github.com/jgm/pandoc/releases/download/1.15.1/pandoc-1.15.1-osx.pkg"
+    "win32": "https://github.com/jgm/pandoc/releases/download/1.16.0.2/pandoc-1.16.0.2-windows.msi",
+    "linux": "https://github.com/jgm/pandoc/releases/download/1.16.0.2/pandoc-1.16.0.2-1-amd64.deb",
+    "darwin": "https://github.com/jgm/pandoc/releases/download/1.16.0.2/pandoc-1.16.0.2-osx.pkg"
 }
 
 

--- a/pypandoc/pandoc_download.py
+++ b/pypandoc/pandoc_download.py
@@ -22,6 +22,7 @@ PANDOC_URLS = {
     "linux": "https://github.com/jgm/pandoc/releases/download/1.16.0.2/pandoc-1.16.0.2-1-amd64.deb",
     "darwin": "https://github.com/jgm/pandoc/releases/download/1.16.0.2/pandoc-1.16.0.2-osx.pkg"
 }
+INCLUDED_PANDOC_VERSION="1.16.0.2"
 
 DEFAULT_TARGET_FOLDER = {
     "win32": "~\\AppData\\Local\\Pandoc",
@@ -29,6 +30,11 @@ DEFAULT_TARGET_FOLDER = {
     "darwin": "~/Applications/pandoc"
 }
 
+
+def _make_executable(path):
+    mode = os.stat(path).st_mode
+    mode |= (mode & 0o444) >> 2    # copy R bits to X
+    os.chmod(path, mode)
 
 def _handle_linux(filename, targetfolder):
 
@@ -50,6 +56,7 @@ def _handle_linux(filename, targetfolder):
             dst = os.path.join(targetfolder, exe)
             print("* Copying %s to %s ..." % (exe, targetfolder))
             shutil.copyfile(src, dst)
+            _make_executable(dst)
         src = os.path.join(tempfolder, "usr", "share", "doc", "pandoc", "copyright")
         dst = os.path.join(targetfolder, "copyright.pandoc")
         print("* Copying copyright to %s ..." % (targetfolder))
@@ -80,6 +87,7 @@ def _handle_darwin(filename, targetfolder):
         dst = os.path.join(targetfolder, exe)
         print("* Copying %s to %s ..." % (exe, targetfolder))
         shutil.copyfile(src, dst)
+        _make_executable(dst)
 
     # remove temporary dir
     shutil.rmtree(tempfolder)

--- a/pypandoc/pandoc_download.py
+++ b/pypandoc/pandoc_download.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+
+import sys
+import os
+import shutil
+import tempfile
+import os.path
+import subprocess
+import platform
+
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib import urlopen
+
+
+# Uses sys.platform keys, but removes the 2 from linux2
+# Adding a new platform means implementing unpacking in "DownloadPandocCommand"
+# and adding the URL here
+PANDOC_URLS = {
+    "win32": "https://github.com/jgm/pandoc/releases/download/1.15.1.1/pandoc-1.15.1.1-windows.msi",
+    "linux": "https://github.com/jgm/pandoc/releases/download/1.15.1/pandoc-1.15.1-1-amd64.deb",
+    "darwin": "https://github.com/jgm/pandoc/releases/download/1.15.1/pandoc-1.15.1-osx.pkg"
+}
+
+
+def _handle_linux(filename, targetfolder):
+
+    print("* Unpacking %s to tempfolder..." % (filename))
+
+    tempfolder = tempfile.mkdtemp()
+    cur_wd = os.getcwd()
+    filename = os.path.abspath(filename)
+    try:
+        os.chdir(tempfolder)
+        cmd = ["ar", "x", filename]
+        # if only 3.5 is supported, should be `run(..., check=True)`
+        subprocess.check_call(cmd)
+        cmd = ["tar", "xzf", "data.tar.gz"]
+        subprocess.check_call(cmd)
+        # pandoc and pandoc-citeproc are in ./usr/bin subfolder
+        for exe in ["pandoc", "pandoc-citeproc"]:
+            src = os.path.join(tempfolder, "usr", "bin", exe)
+            dst = os.path.join(targetfolder, exe)
+            print("* Copying %s to %s ..." % (exe, targetfolder))
+            shutil.copyfile(src, dst)
+        src = os.path.join(tempfolder, "usr", "share", "doc", "pandoc", "copyright")
+        dst = os.path.join(targetfolder, "copyright")
+        print("* Copying copyright to %s ..." % (targetfolder))
+        shutil.copyfile(src, dst)
+    finally:
+        os.chdir(cur_wd)
+        shutil.rmtree(tempfolder)
+
+
+def _handle_darwin(filename, targetfolder):
+    print("* Unpacking %s to tempfolder..." % (filename))
+
+    tempfolder = tempfile.mkdtemp()
+
+    pkgutilfolder = os.path.join(tempfolder, 'tmp')
+    cmd = ["pkgutil", "--expand", filename, pkgutilfolder]
+    # if only 3.5 is supported, should be `run(..., check=True)`
+    subprocess.check_call(cmd)
+
+    # this will generate usr/local/bin below the dir
+    cmd = ["tar", "xvf", os.path.join(pkgutilfolder, "pandoc.pkg", "Payload"),
+           "-C", pkgutilfolder]
+    subprocess.check_call(cmd)
+
+    # pandoc and pandoc-citeproc are in the ./usr/local/bin subfolder
+    for exe in ["pandoc", "pandoc-citeproc"]:
+        src = os.path.join(pkgutilfolder, "usr", "local", "bin", exe)
+        dst = os.path.join(targetfolder, exe)
+        print("* Copying %s to %s ..." % (exe, targetfolder))
+        shutil.copyfile(src, dst)
+
+    # remove temporary dir
+    shutil.rmtree(tempfolder)
+    print("* Done.")
+
+
+def _handle_win32(filename, targetfolder):
+    print("* Unpacking %s to tempfolder..." % (filename))
+
+    tempfolder = tempfile.mkdtemp()
+
+    cmd = ["msiexec", "/a", filename, "/qb", "TARGETDIR=%s" % (tempfolder)]
+    # if only 3.5 is supported, should be `run(..., check=True)`
+    subprocess.check_call(cmd)
+
+    # pandoc.exe, pandoc-citeproc.exe, and the COPYRIGHT are in the Pandoc subfolder
+    for exe in ["pandoc.exe", "pandoc-citeproc.exe", "COPYRIGHT.txt"]:
+        src = os.path.join(tempfolder, "Pandoc", exe)
+        dst = os.path.join(targetfolder, exe)
+        print("* Copying %s to %s ..." % (exe, targetfolder))
+        shutil.copyfile(src, dst)
+
+    # remove temporary dir
+    shutil.rmtree(tempfolder)
+    print("* Done.")
+
+
+def download_pandoc(url=None, targetfolder=None):
+    pf = sys.platform
+    # compatibility with py3
+    if pf.startswith("linux"):
+        pf = "linux"
+        assert platform.architecture()[0] == "64bit", "Linux pandoc is only compiled for 64bit."
+
+    if url is None:
+        try:
+            url = PANDOC_URLS[pf]
+        except:
+            raise Exception("No prebuilt pandoc available or not yet implemented for your platform")
+
+    filename = url.split("/")[-1]
+    if os.path.isfile(filename):
+        print("* Using already downloaded file %s" % (filename))
+    else:
+        print("* Downloading pandoc from %s ..." % url)
+        # https://stackoverflow.com/questions/30627937/tracebaclk-attributeerroraddinfourl-instance-has-no-attribute-exit
+        response = urlopen(url)
+        with open(filename, 'wb') as out_file:
+            shutil.copyfileobj(response, out_file)
+    if targetfolder is None:
+        targetfolder = os.path.join(os.path.dirname(os.path.realpath(__file__)), "pypandoc", "files")
+
+    # Make sure target folder exists...
+    try:
+        os.makedirs(targetfolder)
+    except OSError:
+        pass  # dir already exists...
+
+    unpack = globals().get("_handle_" + pf)
+    assert unpack is not None, "Can't handle download, only Linux, Windows and OS X are supported."
+
+    unpack(filename, targetfolder)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except ImportError:
 try:
     long_description = pypandoc.convert('README.md', 'rst')
     long_description = long_description.replace("\r","")
-except OSError:
+except OSError as e:
     print("\n\n!!! pandoc not found, long_description is bad, don't upload this to PyPI !!!\n\n")
     import io
     # pandoc is not installed, fallback to using raw contents

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,8 @@
 import pypandoc
 from setuptools import setup, Command
 
-import sys
 import os
-import shutil
-import tempfile
 import os.path
-import subprocess
-import platform
 
 try:
     from urllib.request import urlopen
@@ -26,137 +21,25 @@ except OSError:
     with io.open('README.md', encoding="utf-8") as f:
         long_description = f.read()
 
-# Uses sys.platform keys, but removes the 2 from linux2
-# Adding a new platform means implementing unpacking in "DownloadPandocCommand" and adding the URL here
-PANDOC_URLS = {
-    "win32": "https://github.com/jgm/pandoc/releases/download/1.15.1.1/pandoc-1.15.1.1-windows.msi",
-    "linux": "https://github.com/jgm/pandoc/releases/download/1.15.1/pandoc-1.15.1-1-amd64.deb",
-    "darwin": "https://github.com/jgm/pandoc/releases/download/1.15.1/pandoc-1.15.1-osx.pkg"
-}
+
 
 class DownloadPandocCommand(Command):
 
     """Download pandoc"""
 
     description = "downloads a pandoc release and adds it to the package"
-
     user_options = []
 
     def initialize_options(self):
-         pass
+        pass
 
     def finalize_options(self):
-         pass
-
-    def _unpack_linux(self, filename, targetfolder):
-
-        assert platform.architecture()[0] == "64bit", "Downloaded linux pandoc is only compiled for 64bit."
-
-        print("* Unpacking %s to tempfolder..." % (filename))
-
-        tempfolder = tempfile.mkdtemp()
-        cur_wd = os.getcwd()
-        filename = os.path.abspath(filename)
-        try:
-            os.chdir(tempfolder)
-            cmd = ["ar", "x", filename]
-            # if only 3.5 is supported, should be `run(..., check=True)`
-            subprocess.check_call(cmd)
-            cmd = ["tar", "xzf", "data.tar.gz"]
-            subprocess.check_call(cmd)
-            # pandoc and pandoc-citeproc are in ./usr/bin subfolder
-            for exe in ["pandoc", "pandoc-citeproc"]:
-                src = os.path.join(tempfolder, "usr", "bin", exe)
-                dst = os.path.join(targetfolder, exe)
-                print("* Copying %s to %s ..." % (exe, targetfolder))
-                shutil.copyfile(src, dst)
-            src = os.path.join(tempfolder, "usr", "share", "doc", "pandoc", "copyright")
-            dst = os.path.join(targetfolder, "copyright")
-            print("* Copying copyright to %s ..." % (targetfolder))
-            shutil.copyfile(src, dst)
-        finally:
-            os.chdir(cur_wd)
-            shutil.rmtree(tempfolder)
-
-    def _unpack_darwin(self, filename, targetfolder):
-        print("* Unpacking %s to tempfolder..." % (filename))
-
-        tempfolder = tempfile.mkdtemp()
-
-        pkgutilfolder = os.path.join(tempfolder, 'tmp')
-        cmd = ["pkgutil", "--expand", filename, pkgutilfolder]
-        # if only 3.5 is supported, should be `run(..., check=True)`
-        subprocess.check_call(cmd)
-
-        # this will generate usr/local/bin below the dir
-        cmd = ["tar", "xvf", os.path.join(pkgutilfolder, "pandoc.pkg", "Payload"),
-            "-C", pkgutilfolder]
-        subprocess.check_call(cmd)
-
-        # pandoc and pandoc-citeproc are in the ./usr/local/bin subfolder
-        for exe in ["pandoc", "pandoc-citeproc"]:
-            src = os.path.join(pkgutilfolder, "usr", "local", "bin", exe)
-            dst = os.path.join(targetfolder, exe)
-            print("* Copying %s to %s ..." % (exe, targetfolder))
-            shutil.copyfile(src, dst)
-
-        # remove temporary dir
-        shutil.rmtree(tempfolder)
-        print("* Done.")
-
-    def _unpack_win32(self, filename, targetfolder):
-        print("* Unpacking %s to tempfolder..." % (filename))
-
-        tempfolder = tempfile.mkdtemp()
-
-        cmd = ["msiexec", "/a", filename, "/qb", "TARGETDIR=%s" % (tempfolder)]
-        # if only 3.5 is supported, should be `run(..., check=True)`
-        subprocess.check_call(cmd)
-
-        # pandoc.exe, pandoc-citeproc.exe, and the COPYRIGHT are in the Pandoc subfolder
-        for exe in ["pandoc.exe", "pandoc-citeproc.exe", "COPYRIGHT.txt"]:
-            src = os.path.join(tempfolder, "Pandoc", exe)
-            dst = os.path.join(targetfolder, exe)
-            print("* Copying %s to %s ..." % (exe, targetfolder))
-            shutil.copyfile(src, dst)
-
-        # remove temporary dir
-        shutil.rmtree(tempfolder)
-        print("* Done.")
-
+        pass
 
     def run(self):
-        pf = sys.platform
-        # compatibility with py3
-        if pf.startswith("linux"):
-            pf = "linux"
-
-        try:
-            url = PANDOC_URLS[pf]
-        except:
-            raise Exception("No prebuilt pandoc available or not yet implemented for your platform")
-
-        filename = url.split("/")[-1]
-        if os.path.isfile(filename):
-            print("* Using already downloaded file %s" % (filename))
-        else:
-            print("* Downloading pandoc from %s ..." % url)
-            # https://stackoverflow.com/questions/30627937/tracebaclk-attributeerroraddinfourl-instance-has-no-attribute-exit
-            response = urlopen(url)
-            with open(filename, 'wb') as out_file:
-                shutil.copyfileobj(response, out_file)
-
+        from pypandoc.pandoc_download import download_pandoc
         targetfolder = os.path.join(os.path.dirname(os.path.realpath(__file__)), "pypandoc", "files")
-
-        # Make sure target folder exists...
-        try:
-            os.makedirs(targetfolder)
-        except OSError:
-            pass # dir already exists...
-
-        unpack = getattr(self, "_unpack_"+pf)
-
-        unpack(filename, targetfolder)
+        download_pandoc(targetfolder=targetfolder)
 
 
 cmd_classes = {'download_pandoc': DownloadPandocCommand}

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,15 @@
 [tox]
-envlist = py26, py27, py33, py34, pypy, pypy3, flake8
+envlist = py26, py27, py33, py34, py35, pypy, pypy3, flake8
 
 [testenv]
+# pandoc does not like it when HOME is missing...
+passenv=HOME
 commands =
-    python tests.py
+	python --version
+	python -c "import pypandoc; print(pypandoc.get_pandoc_version())"
+	# make sure we use our own pandoc version
+ 	python -c "import sys; import pypandoc; from pypandoc.pandoc_download import INCLUDED_PANDOC_VERSION as IPV; pypandoc.get_pandoc_version() == IPV or sys.exit(-1)"
+	python tests.py
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
This does two things:
* It refactors the old setup.py based download function so that it is a user function which can be called by the user and by setup.py
* the new functions gets some default target folder for the download and these folder + a few default platform specific folders get added to the search path

The result should be that if you install the pandoc on your system, pypandoc should find it... And if you don't have a pandoc installed, it is only a `pypandoc.download_pandoc()` away...

If there are a typical install location missing, please leave a comment...

Closes: #91 -> new pandoc version
Closes: #84 -> new cleaner workaround for making a wheel platform specific
Closes: #90 -> new workaround should compile on py35
Closes: #83 -> now available as `pypandoc.download_pandoc([url, targetfolder])`