### PR TITLE
Fixed installation and execution of tests on Mac OS X. The setup.py c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ pandoc is available for many different platforms:
 - Ubuntu/Debian: `sudo apt-get install pandoc`
 - Fedora/Red Hat: `sudo yum install pandoc`
 - Arch: `sudo pacman -S pandoc`
-- Mac OS X with Homebrew: `brew install pandoc`
+- Mac OS X with Homebrew: `brew install pandoc pandoc-citeproc Caskroom/cask/mactex`
 - Machine with Haskell: `cabal-install pandoc`
 - Windows: There is an installer available
   [here](http://johnmacfarlane.net/pandoc/installing.html)

--- a/setup.py
+++ b/setup.py
@@ -222,7 +222,7 @@ setup(
     author_email = 'bebraw@gmail.com',
     packages = ['pypandoc'],
     package_data={'pypandoc': ['files/*']},
-    install_requires = ['setuptools', ],
+    install_requires = ['setuptools', 'pip>=8.1.0', 'wheel>=0.25.0'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
Fixed #90 failure to install on OS X with Python 3.5, also includes improved installation instructions so the test execution will not fail due to missing tools.