### PR TITLE
Bugfix for search path and update to newer pandoc version

### DIFF
--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -303,11 +303,10 @@ def _ensure_pandoc_path():
         # Also add the interpreter script path, as that's where pandoc could be
         # installed if it's an environment and the environment wasn't activated
         if pf == "win32":
-            search_paths.append(os.path.join(sys.exec_prefix, "Scripts"))
-            # on windows, Library\bin could also be used, but that's already in
-            # path by the interpreter!
-        else:
-            search_paths.append(os.path.join(sys.exec_prefix, "bin"))
+            search_paths.append(os.path.join(sys.exec_prefix, "Scripts", "pandoc"))
+        # bin can also be used on windows (conda at leats has it in path), so
+        # include it unconditionally
+        search_paths.append(os.path.join(sys.exec_prefix, "bin", "pandoc"))
         # If a user added the complete path to pandoc to an env, use that as the
         # only way to get pandoc so that a user can overwrite even a higher
         # version in some other places.

--- a/pypandoc/pandoc_download.py
+++ b/pypandoc/pandoc_download.py
@@ -18,12 +18,12 @@ except ImportError:
 # Adding a new platform means implementing unpacking in "DownloadPandocCommand"
 # and adding the URL here
 PANDOC_URLS = {
-    "win32": "https://github.com/jgm/pandoc/releases/download/1.16.0.2/pandoc-1.16.0.2-windows.msi",
-    "linux": "https://github.com/jgm/pandoc/releases/download/1.16.0.2/pandoc-1.16.0.2-1-amd64.deb",
-    "darwin": "https://github.com/jgm/pandoc/releases/download/1.16.0.2/pandoc-1.16.0.2-osx.pkg"
+    "win32": "https://github.com/jgm/pandoc/releases/download/1.17.0.2/pandoc-1.17.0.2-windows.msi",
+    "linux": "https://github.com/jgm/pandoc/releases/download/1.17.0.2/pandoc-1.17.0.2-1-amd64.deb",
+    "darwin": "https://github.com/jgm/pandoc/releases/download/1.17.0.2/pandoc-1.17.0.2-osx.pkg"
 }
 
-INCLUDED_PANDOC_VERSION = "1.16.0.2"
+INCLUDED_PANDOC_VERSION = "1.17.0.2"
 
 DEFAULT_TARGET_FOLDER = {
     "win32": "~\\AppData\\Local\\Pandoc",


### PR DESCRIPTION
The search path in one case was missing the binary name in the end (`pandoc`).

Fixes: https://github.com/bebraw/pypandoc/issues/94