### PR TITLE
New main api: convert_file and convert_text

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,43 +9,64 @@ document converter.
 
 ## Installation
 
-pypandoc uses pandoc, so it needs an available installation of pandoc. For some common cases
-(wheels, conda packages), pypandoc already includes pandoc (and pandoc_citeproc) in it's
+pypandoc uses `pandoc`, so it needs an available installation of `pandoc`. For some common cases
+(wheels, conda packages), pypandoc already includes `pandoc` (and `pandoc_citeproc`) in it's
 prebuilt package.
 
-If pandoc is already installed (`pandoc` is in the PATH), pypandoc uses the version with the
+If `pandoc` is already installed (`pandoc` is in the PATH), `pypandoc` uses the version with the
 higher version number and if both are the same, the already installed version. See [Specifying the location of pandoc binaries](#specifying_binaries) for more.
 
-To use pandoc filters, you must have the relevant filter installed on your machine.
+To use `pandoc` filters, you must have the relevant filter installed on your machine.
 
 ### Installing via pip
 
-Install via `pip install pypandoc`
+Install via `pip install pypandoc`.
 
 Prebuilt [wheels for Windows and Mac OS X](https://pypi.python.org/pypi/pypandoc/) include
 pandoc. If there is no prebuilt binary available, you have to
-[install pandoc yourself](#installing-pandoc).
+[install `pandoc` yourself](#installing-pandoc).
 
 If you use Linux and have [your own wheelhouse](http://wheel.readthedocs.org/en/latest/#usage),
-you can build a wheel which includes pandoc with
+you can build a wheel which include `pandoc` with
 `python setup.py download_pandoc; python setup.py bdist_wheel`. Be aware that this works only
 on 64bit intel systems, as we only download it from the
 [official source](https://github.com/jgm/pandoc/releases).
 
 ### Installing via conda
 
-Install via `conda install -c https://conda.anaconda.org/janschulz pypandoc`.
+`pypandoc` is included in [conda-forge](https://conda-forge.github.io/). The conda packages will
+also install the `pandoc` package, so `pandoc` is available in the installation.
+
+Install via `conda install -c conda-forge pypandoc`.
 
 You can also add the channel to your conda config via
-`conda config --add channels https://conda.anaconda.org/janschulz`. This makes it possible to
+`conda config --add channels conda-forge`. This makes it possible to
 use `conda install pypandoc` directly and also lets you update via `conda update pypandoc`.
-
-Conda packages include pandoc and are available for py2.7, py3.4 and py3.5,
-for Windows (32bit and 64bit), Mac OS X (64bit) and Linux (64bit).
 
 ### Installing pandoc
 
-pandoc is available for many different platforms:
+If you don't get `pandoc` installed via a prebuild wheel which includes `pandoc` or via the
+conda package dependencies, you need to install `pandoc` by yourself.
+
+#### Installing pandoc via pypandoc
+
+Installing via pypandoc is possible on Windows, Mac OS X or Linux (Intel-based):
+
+```python
+# expects a installed pypandoc: pip install pypandoc
+from pypandoc.pandoc_download import download_pandoc
+# see the documentation how to customize the installation path
+# but be aware that you then need to include it in the PATH
+download_pandoc()
+```
+
+The default install location is included in the search path for `pandoc`, so you
+don't need to add it to `PATH`.
+
+#### Installing pandoc manually
+
+Installing manually via the system mechanismen is also possible. Such installation mechanismen
+make `pandoc` available on many more platforms:
 
 - Ubuntu/Debian: `sudo apt-get install pandoc`
 - Fedora/Red Hat: `sudo yum install pandoc`
@@ -56,6 +77,10 @@ pandoc is available for many different platforms:
   [here](http://johnmacfarlane.net/pandoc/installing.html)
 - [FreeBSD port](http://www.freshports.org/textproc/pandoc/)
   - Or see http://johnmacfarlane.net/pandoc/installing.html
+
+Be aware that not all install mechanismen put `pandoc` in `PATH`, so you either
+have to change `PATH` yourself or set the full path to `pandoc` in
+`PYPANDOC_PANDOC`. See the next section for more information.
 
 ### <a name="specifying_binaries"></a>Specifying the location of pandoc binaries
 
@@ -70,40 +95,44 @@ os.environ.setdefault('PYPANDOC_PANDOC', '/home/x/whatever/pandoc')
 
 ## Usage
 
-The basic invocation looks like this: `pypandoc.convert('input', 'output format')`. `pypandoc`
-tries to infer the type of the input automatically. If it's a file, it will load it. In case you
-pass a string, you can define the `format` using the parameter. The example below should clarify
-the usage:
+There are two basic ways to use `pypandoc`: with input files or with input
+strings.
+
 
 ```python
 import pypandoc
 
-output = pypandoc.convert('somefile.md', 'rst')
+# With an input file: it will infer the input format from the filename
+output = pypandoc.convert_file('somefile.md', 'rst')
 
-# alternatively you could just pass some string to it and define its format
-output = pypandoc.convert('#some title', 'rst', format='md')
+# ...but you can overwrite the format via the `format` argument:
+output = pypandoc.convert_file('somefile.txt', 'rst', format='md')
+
+# alternatively you could just pass some string. In this case you need to
+# define the input format:
+output = pypandoc.convert_text('#some title', 'rst', format='md')
 # output == 'some title\r\n==========\r\n\r\n'
 ```
 
-If you pass in a string (and not a filename), `convert` expects this string to be unicode or
-utf-8 encoded bytes. `convert` will always return a unicode string.
+`convert_text` expects this string to be unicode or utf-8 encoded bytes. `convert_*` will always
+return a unicode string.
 
-It's also possible to directly let pandoc write the output to a file. This is the only way to
-convert to some output formats (e.g. odt, docx, epub, epub3, pdf). In that case `convert()` will
+It's also possible to directly let `pandoc` write the output to a file. This is the only way to
+convert to some output formats (e.g. odt, docx, epub, epub3, pdf). In that case `convert_*()` will
 return an empty string.
 
 ```python
 import pypandoc
 
-output = pypandoc.convert('somefile.md', 'docx', outputfile="somefile.docx")
+output = pypandoc.convert_file('somefile.md', 'docx', outputfile="somefile.docx")
 assert output == ""
 ```
 
 In addition to `format`, it is possible to pass `extra_args`.
-That makes it possible to access various pandoc options easily.
+That makes it possible to access various `pandoc` options easily.
 
 ```python
-output = pypandoc.convert(
+output = pypandoc.convert_text(
     '<h1>Primary Heading</h1>',
     'md', format='html',
     extra_args=['--atx-headers'])
@@ -121,53 +150,51 @@ pypandoc now supports easy addition of
 filters = ['pandoc-citeproc']
 pdoc_args = ['--mathjax',
              '--smart']
-output = pd.convert(source=filename,
-                    to='html5',
-                    format='md',
-                    extra_args=pdoc_args,
-                    filters=filters)
+output = pd.convert_file(source=filename,
+                         to='html5',
+                         format='md',
+                         extra_args=pdoc_args,
+                         filters=filters)
 ```
-Please pass any filters in as a list and not a string.
+Please pass any filters in as a list and not as a string.
 
 Please refer to `pandoc -h` and the
 [official documentation](http://johnmacfarlane.net/pandoc/README.html) for further details.
 
+> Note: the old way of using `convert(input, output)` is deprecated as in some cases it wasn't
+possible to determine whether the input should be used as a filename or as text.
+
 ## Dealing with Formatting Arguments
 
-Pandoc supports custom formatting though `-V` parameter. In order to use it through pypandoc, use code such as this:
+Pandoc supports custom formatting though `-V` parameter. In order to use it through
+pypandoc, use code such as this:
 
 ```python
-output = pypandoc.convert('demo.md', 'pdf', outputfile='demo.pdf',
+output = pypandoc.convert_file('demo.md', 'pdf', outputfile='demo.pdf',
   extra_args=['-V', 'geometry:margin=1.5cm'])
 ```
 
-Note that it's important to separate `-V` and its argument within a list like that or else it won't work. This gotcha has to do with the way `subprocess.Popen` works.
+> Note: it's important to separate `-V` and its argument within a list like that or else
+it won't work. This gotcha has to do with the way
+[`subprocess.Popen`](https://docs.python.org/2/library/subprocess.html#subprocess.Popen) works.
 
 ## Getting Pandoc Version
 
-As it can be useful sometimes to check what Pandoc version is available at your system, `pypandoc` provides an utility for this. Example:
+As it can be useful sometimes to check what Pandoc version is available at your system or which
+particular `pandoc` binary is used by `pypandoc`. For that, `pypandoc` provides the following
+utility functions. Example:
 
 ```
-version = pypandoc.get_pandoc_version()
+print(pypandoc.get_pandoc_version())
+print(pypandoc.get_pandoc_path())
+print(pypandoc.get_pandoc_formats())
 ```
 
 ## Related
 
-[pydocverter](https://github.com/msabramo/pydocverter) is a client for a service called
-[Docverter](http://www.docverter.com/), which offers pandoc as a service (plus some extra goodies).
-It has the same API as pypandoc, so you can easily write code that uses one and falls back to the
-other. E.g.:
-
-```python
-try:
-    import pypandoc as converter
-except ImportError:
-    import pydocverter as converter
-
-converter.convert('somefile.md', 'rst')
-```
-
-See [pyandoc](http://pypi.python.org/pypi/pyandoc/) for an alternative implementation of a pandoc
+* [pydocverter](https://github.com/msabramo/pydocverter) is a client for a service called
+[Docverter](http://www.docverter.com/), which offers `pandoc` as a service (plus some extra goodies).
+* See [pyandoc](http://pypi.python.org/pypi/pyandoc/) for an alternative implementation of a `pandoc`
 wrapper from Kenneth Reitz. This one hasn't been active in a while though.
 
 ## Contributing
@@ -176,7 +203,7 @@ Contributions are welcome. When opening a PR, please keep the following guidelin
 
 1. Before implementing, please open an issue for discussion.
 2. Make sure you have tests for the new logic.
-3. Make sure your code passes `flake8 pypandoc.py tests.py`
+3. Make sure your code passes `flake8 pypandoc/*.py tests.py`
 4. Add yourself to contributors at `README.md` unless you are already there. In that case tweak your contributions.
 
 Note that for citeproc tests to pass you'll need to have [pandoc-citeproc](https://github.com/jgm/pandoc-citeproc) installed. If you installed a prebuilt wheel or conda package, it is already included.
@@ -199,12 +226,12 @@ Note that for citeproc tests to pass you'll need to have [pandoc-citeproc](https
 * [Amy Guy](https://github.com/rhiaro) - Exception handling for unicode errors
 * [Florian Eßer](https://github.com/flesser) - Allow Markdown extensions in output format
 * [Philipp Wendler](https://github.com/PhilippWendler) - Allow Markdown extensions in input format
-* [Jan Schulz](https://github.com/JanSchulz) - Handling output to a file, Travis to work on newer version of Pandoc, return code checking, get_pandoc_version. Helped to fix the Travis build.
+* [Jan Schulz](https://github.com/JanSchulz) - Handling output to a file, Travis to work on newer version of Pandoc, return code checking, get_pandoc_version. Helped to fix the Travis build, new `convert_*` API
 * [Aaron Gonzales](https://github.com/xysmas) - Added better filter handling
 * [David Lukes](https://github.com/dlukes) - Enabled input from non-plain-text files and made sure tests clean up template files correctly if they fail
 * [valholl](https://github.com/valholl) - Set up licensing information correctly and include examples to distribution version
-* [Cyrille Rossant](https://github.com/rossant) - Fixed bug by trimming out stars in the list of pandoc formats. Helped to fix the Travis build.
-* [Paul Osborne](https://github.com/posborne) - Don't require pandoc to install pypandoc.
+* [Cyrille Rossant](https://github.com/rossant) - Fixed bug by trimming out stars in the list of `pandoc` formats. Helped to fix the Travis build.
+* [Paul Osborne](https://github.com/posborne) - Don't require `pandoc` to install pypandoc.
 * [Felix Yan](https://github.com/felixonmars) - Added installation instructions for Arch Linux.
 
 ## License

--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -56,6 +56,9 @@ def convert(source, to, format=None, extra_args=(), encoding='utf-8',
     else:
         source = _as_unicode(source, encoding)
         input_type = 'string'
+        if not format:
+            raise RuntimeError("Format missing, but need one (identified source as text as no "
+                               "file with that name was found).")
     return _convert_input(source, format, input_type, to, extra_args=extra_args,
                           outputfile=outputfile, filters=filters)
 
@@ -137,6 +140,9 @@ def _identify_path(source):
     except UnicodeEncodeError:
         path = os.path.exists(source.encode('utf-8'))
     except ValueError:
+        path = False
+    except TypeError:
+        # source is None...
         path = False
     return path
 

--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -48,14 +48,7 @@ def convert(source, to, format=None, extra_args=(), encoding='utf-8',
     :raises OSError: if pandoc is not found; make sure it has been installed and is available at
             path.
     """
-    return _convert(_read_file, _process_file, source, to,
-                    format, extra_args, encoding=encoding,
-                    outputfile=outputfile, filters=filters)
-
-
-def _convert(reader, processor, source, to, format=None, extra_args=(), encoding=None,
-             outputfile=None, filters=None):
-    source, format, input_type = reader(source, format, encoding=encoding)
+    source, format, input_type = _read_file(source, format, encoding=encoding)
 
     formats = {
         'dbk': 'docbook',
@@ -90,7 +83,7 @@ def _convert(reader, processor, source, to, format=None, extra_args=(), encoding
             'Output to %s only works by using a outputfile.' % base_to_format
         )
 
-    return processor(source, input_type, to, format, extra_args,
+    return _process_file(source, input_type, to, format, extra_args,
                      outputfile=outputfile, filters=filters)
 
 

--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -14,8 +14,9 @@ from pypandoc.pandoc_download import DEFAULT_TARGET_FOLDER, download_pandoc
 __author__ = u'Juho Vepsäläinen'
 __version__ = '1.1.3'
 __license__ = 'MIT'
-__all__ = ['convert', 'get_pandoc_formats', 'get_pandoc_version',
-           'get_pandoc_path', 'download_pandoc']
+__all__ = ['convert', 'convert_file', 'convert_text',
+           'get_pandoc_formats', 'get_pandoc_version', 'get_pandoc_path',
+           'download_pandoc']
 
 
 def convert(source, to, format=None, extra_args=(), encoding='utf-8',
@@ -48,8 +49,125 @@ def convert(source, to, format=None, extra_args=(), encoding='utf-8',
     :raises OSError: if pandoc is not found; make sure it has been installed and is available at
             path.
     """
-    source, format, input_type = _read_file(source, format, encoding=encoding)
+    path = _identify_path(source)
+    if path:
+        format = _identify_format_from_path(source, format)
+        input_type = 'path'
+    else:
+        source = _as_unicode(source, encoding)
+        input_type = 'string'
+    return _convert_input(source, format, input_type, to, extra_args=extra_args,
+                          outputfile=outputfile, filters=filters)
 
+
+def convert_text(source, to, format, extra_args=(), encoding='utf-8',
+                 outputfile=None, filters=None):
+
+    """Converts given `source` from `format` `to` another.
+
+    :param str source: Unicode string or bytes (see encoding)
+
+    :param str to: format into which the input should be converted; can be one of
+            `pypandoc.get_pandoc_formats()[1]`
+
+    :param str format: the format of the inputs; can be one of `pypandoc.get_pandoc_formats()[1]`
+
+    :param list extra_args: extra arguments (list of strings) to be passed to pandoc
+            (Default value = ())
+
+    :param str encoding: the encoding of the input bytes (Default value = 'utf-8')
+
+    :param str outputfile: output will be written to outfilename or the converted content
+            returned if None (Default value = None)
+
+    :param list filters: pandoc filters e.g. filters=['pandoc-citeproc']
+
+    :returns: converted string (unicode) or an empty string if an outputfile was given
+    :rtype: unicode
+
+    :raises RuntimeError: if any of the inputs are not valid of if pandoc fails with an error
+    :raises OSError: if pandoc is not found; make sure it has been installed and is available at
+            path.
+    """
+    source = _as_unicode(source, encoding)
+    return _convert_input(source, format, 'string', to, extra_args=extra_args,
+                          outputfile=outputfile, filters=filters)
+
+
+def convert_file(source_file, to, format=None, extra_args=(), encoding='utf-8',
+                 outputfile=None, filters=None):
+    """Converts given `source` from `format` `to` another.
+
+    :param str source_file: file path (see encoding)
+
+    :param str to: format into which the input should be converted; can be one of
+            `pypandoc.get_pandoc_formats()[1]`
+
+    :param str format: the format of the inputs; will be inferred from the source_file with an
+            known filename extension; can be one of `pypandoc.get_pandoc_formats()[1]`
+            (Default value = None)
+
+    :param list extra_args: extra arguments (list of strings) to be passed to pandoc
+            (Default value = ())
+
+    :param str encoding: the encoding of the file or the input bytes (Default value = 'utf-8')
+
+    :param str outputfile: output will be written to outfilename or the converted content
+            returned if None (Default value = None)
+
+    :param list filters: pandoc filters e.g. filters=['pandoc-citeproc']
+
+    :returns: converted string (unicode) or an empty string if an outputfile was given
+    :rtype: unicode
+
+    :raises RuntimeError: if any of the inputs are not valid of if pandoc fails with an error
+    :raises OSError: if pandoc is not found; make sure it has been installed and is available at
+            path.
+    """
+    if not _identify_path(source_file):
+        raise RuntimeError("source_file is not a valid path")
+    format = _identify_format_from_path(source_file, format)
+    return _convert_input(source_file, format, 'path', to, extra_args=extra_args,
+                          outputfile=outputfile, filters=filters)
+
+
+def _identify_path(source):
+    try:
+        path = os.path.exists(source)
+    except UnicodeEncodeError:
+        path = os.path.exists(source.encode('utf-8'))
+    except ValueError:
+        path = False
+    return path
+
+
+def _identify_format_from_path(sourcefile, format):
+    return format or os.path.splitext(sourcefile)[1].strip('.')
+
+
+def _as_unicode(source, encoding):
+    if encoding != 'utf-8':
+        # if a source and a different encoding is given, try to decode the the source into a
+        # unicode string
+        try:
+            source = cast_unicode(source, encoding=encoding)
+        except (UnicodeDecodeError, UnicodeEncodeError):
+            pass
+    return source
+
+
+def _identify_input_type(source, format, encoding='utf-8'):
+    path = _identify_path(source)
+    if path:
+        format = _identify_format_from_path(source, format)
+        input_type = 'path'
+    else:
+        source = _as_unicode(source, encoding)
+        input_type = 'string'
+    return source, format, input_type
+
+
+def _validate_formats(format, to, outputfile):
     formats = {
         'dbk': 'docbook',
         'md': 'markdown',
@@ -82,36 +200,15 @@ def convert(source, to, format=None, extra_args=(), encoding='utf-8',
         raise RuntimeError(
             'Output to %s only works by using a outputfile.' % base_to_format
         )
-
-    return _process_file(source, input_type, to, format, extra_args,
-                     outputfile=outputfile, filters=filters)
+    return format, to
 
 
-def _read_file(source, format, encoding='utf-8'):
-    try:
-        path = os.path.exists(source)
-    except UnicodeEncodeError:
-        path = os.path.exists(source.encode('utf-8'))
-    except ValueError:
-        path = ''
-    if path:
-        format = format or os.path.splitext(source)[1].strip('.')
-        input_type = 'path'
-    else:
-        if encoding != 'utf-8':
-            # if a source and a different encoding is given, try to decode the the source into a
-            # unicode string
-            try:
-                source = cast_unicode(source, encoding=encoding)
-            except (UnicodeDecodeError, UnicodeEncodeError):
-                pass
-        input_type = 'string'
-    return source, format, input_type
-
-
-def _process_file(source, input_type, to, format, extra_args, outputfile=None,
-                  filters=None):
+def _convert_input(source, format, input_type, to, extra_args=(), outputfile=None,
+                   filters=None):
     _ensure_pandoc_path()
+
+    format, to = _validate_formats(format, to, outputfile)
+
     string_input = input_type == 'string'
     input_file = [source] if not string_input else []
     args = [__pandoc_path, '--from=' + format]

--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -6,6 +6,7 @@ import sys
 import textwrap
 import os
 import re
+import warnings
 
 from .py3compat import string_types, cast_bytes, cast_unicode
 
@@ -21,7 +22,7 @@ __all__ = ['convert', 'convert_file', 'convert_text',
 
 def convert(source, to, format=None, extra_args=(), encoding='utf-8',
             outputfile=None, filters=None):
-    """Converts given `source` from `format` `to` another.
+    """Converts given `source` from `format` to `to`.
 
     :param str source: Unicode string or bytes or a file path (see encoding)
 
@@ -49,6 +50,10 @@ def convert(source, to, format=None, extra_args=(), encoding='utf-8',
     :raises OSError: if pandoc is not found; make sure it has been installed and is available at
             path.
     """
+    msg = ("Due to possible ambiguity, 'convert()' is deprecated. "
+           "Use 'convert_file()'  or 'convert_text()'.")
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
+
     path = _identify_path(source)
     if path:
         format = _identify_format_from_path(source, format)
@@ -66,7 +71,7 @@ def convert(source, to, format=None, extra_args=(), encoding='utf-8',
 def convert_text(source, to, format, extra_args=(), encoding='utf-8',
                  outputfile=None, filters=None):
 
-    """Converts given `source` from `format` `to` another.
+    """Converts given `source` from `format` to `to`.
 
     :param str source: Unicode string or bytes (see encoding)
 
@@ -99,7 +104,7 @@ def convert_text(source, to, format, extra_args=(), encoding='utf-8',
 
 def convert_file(source_file, to, format=None, extra_args=(), encoding='utf-8',
                  outputfile=None, filters=None):
-    """Converts given `source` from `format` `to` another.
+    """Converts given `source` from `format` to `to`.
 
     :param str source_file: file path (see encoding)
 

--- a/tests.py
+++ b/tests.py
@@ -88,6 +88,10 @@ class TestPypandoc(unittest.TestCase):
         received = pypandoc.convert('#some title', 'rst', format='md')
         self.assertEqualExceptForNewlineEnd(expected, received)
 
+        expected = u'some title{0}=========={0}{0}'.format(os.linesep)
+        received = pypandoc.convert_text('#some title', 'rst', format='md')
+        self.assertEqualExceptForNewlineEnd(expected, received)
+
     def test_conversion_with_markdown_extensions(self):
         input = '<s>strike</s>'
         expected_with_extension = u'~~strike~~'
@@ -248,6 +252,25 @@ class TestPypandoc(unittest.TestCase):
     def test_get_pandoc_path(self):
         result = pypandoc.get_pandoc_path()
         assert "pandoc" in result
+
+    def test_call_with_nonexisting_file(self):
+        files = ['/file/does/not/exists.md',
+                 '',
+                 42,
+                 None
+                 ]
+
+        def f(filepath):
+            pypandoc.convert(filepath, 'rst')
+
+        for filepath in files:
+            self.assertRaises(RuntimeError, f, filepath)
+
+        def f(filepath):
+            pypandoc.convert_file(filepath, 'rst')
+
+        for filepath in files:
+            self.assertRaises(RuntimeError, f, filepath)
 
     def assertEqualExceptForNewlineEnd(self, expected, received):
         # output written to a file does not seem to have os.linesep

--- a/tests.py
+++ b/tests.py
@@ -4,9 +4,10 @@
 import unittest
 import tempfile
 import pypandoc
-from pypandoc.py3compat import unicode_type
+from pypandoc.py3compat import unicode_type, string_types
 import os
 import sys
+import warnings
 
 import contextlib
 import shutil
@@ -21,6 +22,82 @@ def closed_tempfile(suffix, text=None):
             test_file.flush()
     yield file_name
     shutil.rmtree(file_name, ignore_errors=True)
+
+
+# Stolen from pandas
+def is_list_like(arg):
+    return (hasattr(arg, '__iter__') and
+            not isinstance(arg, string_types))
+
+
+@contextlib.contextmanager
+def assert_produces_warning(expected_warning=Warning, filter_level="always",
+                            clear=None, check_stacklevel=True):
+    """
+    Context manager for running code that expects to raise (or not raise)
+    warnings.  Checks that code raises the expected warning and only the
+    expected warning. Pass ``False`` or ``None`` to check that it does *not*
+    raise a warning. Defaults to ``exception.Warning``, baseclass of all
+    Warnings. (basically a wrapper around ``warnings.catch_warnings``).
+    >>> import warnings
+    >>> with assert_produces_warning():
+    ...     warnings.warn(UserWarning())
+    ...
+    >>> with assert_produces_warning(False):
+    ...     warnings.warn(RuntimeWarning())
+    ...
+    Traceback (most recent call last):
+        ...
+    AssertionError: Caused unexpected warning(s): ['RuntimeWarning'].
+    >>> with assert_produces_warning(UserWarning):
+    ...     warnings.warn(RuntimeWarning())
+    Traceback (most recent call last):
+        ...
+    AssertionError: Did not see expected warning of class 'UserWarning'.
+    ..warn:: This is *not* thread-safe.
+    """
+    with warnings.catch_warnings(record=True) as w:
+
+        if clear is not None:
+            # make sure that we are clearning these warnings
+            # if they have happened before
+            # to guarantee that we will catch them
+            if not is_list_like(clear):
+                clear = [clear]
+            for m in clear:
+                try:
+                    m.__warningregistry__.clear()
+                except:
+                    pass
+
+        saw_warning = False
+        warnings.simplefilter(filter_level)
+        yield w
+        extra_warnings = []
+
+        for actual_warning in w:
+            if (expected_warning and issubclass(actual_warning.category,
+                                                expected_warning)):
+                saw_warning = True
+
+                if check_stacklevel and issubclass(actual_warning.category,
+                                                   (FutureWarning,
+                                                    DeprecationWarning)):
+                    from inspect import getframeinfo, stack
+                    caller = getframeinfo(stack()[2][0])
+                    msg = ("Warning not set with correct stacklevel. "
+                           "File where warning is raised: {0} != {1}. "
+                           "Warning message: {2}".format(
+                               actual_warning.filename, caller.filename,
+                               actual_warning.message))
+                    assert actual_warning.filename == caller.filename, msg
+            else:
+                extra_warnings.append(actual_warning.category.__name__)
+        if expected_warning:
+            assert saw_warning, ("Did not see expected warning of class %r."
+                                 % expected_warning.__name__)
+        assert not extra_warnings, ("Caused unexpected warning(s): %r."
+                                    % extra_warnings)
 
 
 class TestPypandoc(unittest.TestCase):
@@ -253,6 +330,11 @@ class TestPypandoc(unittest.TestCase):
             # The following is a problematic case
             received = pypandoc.convert(file_name, 'rst', format='md')
             self.assertTrue("title" in received)
+
+    def test_depreaction_warnings(self):
+        # convert itself is deprecated...
+        with assert_produces_warning(DeprecationWarning):
+            pypandoc.convert('#some title\n', to='rst', format='md')
 
     def assertEqualExceptForNewlineEnd(self, expected, received):
         # output written to a file does not seem to have os.linesep

--- a/tests.py
+++ b/tests.py
@@ -11,6 +11,7 @@ import sys
 import contextlib
 import shutil
 
+
 @contextlib.contextmanager
 def closed_tempfile(suffix, text=None):
     with tempfile.NamedTemporaryFile('w+t', suffix=suffix, delete=False) as test_file:
@@ -243,6 +244,15 @@ class TestPypandoc(unittest.TestCase):
 
         for filepath in files:
             self.assertRaises(RuntimeError, f, filepath)
+
+    def test_convert_text_with_existing_file(self):
+        with closed_tempfile('.md', text='#some title\n') as file_name:
+            received = pypandoc.convert_text(file_name, 'rst', format='md')
+            self.assertTrue("title" not in received)
+
+            # The following is a problematic case
+            received = pypandoc.convert(file_name, 'rst', format='md')
+            self.assertTrue("title" in received)
 
     def assertEqualExceptForNewlineEnd(self, expected, received):
         # output written to a file does not seem to have os.linesep

--- a/tests.py
+++ b/tests.py
@@ -9,20 +9,6 @@ import os
 import sys
 
 
-def test_converter(to, format=None, extra_args=()):
-
-    def reader(*args, **kwargs):
-        return source, format, input_type
-
-    def processor(*args, **kwargs):
-        return 'ok'
-
-    source = 'foo'
-    input_type = 'string'
-
-    return pypandoc._convert(reader, processor, source, to, format, extra_args)
-
-
 class TestPypandoc(unittest.TestCase):
 
     def setUp(self):
@@ -53,19 +39,17 @@ class TestPypandoc(unittest.TestCase):
         self.assertTrue(major in [0, 1])
 
     def test_converts_valid_format(self):
-        self.assertEqual(test_converter(format='md', to='rest'), 'ok')
+        self.assertEqualExceptForNewlineEnd(pypandoc.convert("ok", format='md', to='rest'), 'ok')
 
     def test_does_not_convert_to_invalid_format(self):
-        try:
-            test_converter(format='md', to='invalid')
-        except RuntimeError:
-            pass
+        def f():
+            pypandoc.convert("ok", format='md', to='invalid')
+        self.assertRaises(RuntimeError, f)
 
     def test_does_not_convert_from_invalid_format(self):
-        try:
-            test_converter(format='invalid', to='rest')
-        except RuntimeError:
-            pass
+        def f():
+            pypandoc.convert("ok", format='invalid', to='rest')
+        self.assertRaises(RuntimeError, f)
 
     # We can't use skipIf as it is not available in py2.6
     # @unittest.skipIf(sys.platform.startswith("win"), "NamedTemporaryFile does not work on Windows")


### PR DESCRIPTION
This introduces `convert_text()` and `convert_file()` as a successor to `convert()`. It also adds a few tweaks to the `convert()` path, so that it will give better error messages (more or less for https://github.com/bebraw/pypandoc/issues/86), but the real fix is to convert `convert()` calls into the new  `conver_*()` ones...

Also cleans up the old separation of the functions which seems to be only used by the tests, reactors tests and enables more tests on windows, adds tests for the new ways to use the library and updates the readme (including a new source where you can get the conda packages)

This closes: https://github.com/bebraw/pypandoc/issues/86