### PR TITLE
Ensure $HOME is set before calling `pandoc --version`

### DIFF
--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -7,6 +7,7 @@ import textwrap
 import os
 import re
 import warnings
+import tempfile
 
 from .py3compat import string_types, cast_bytes, cast_unicode
 
@@ -344,10 +345,14 @@ def get_pandoc_formats():
 # copied and adapted from jupyter_nbconvert/utils/pandoc.py, Modified BSD License
 
 def _get_pandoc_version(pandoc_path):
+    new_env = os.environ.copy()
+    if 'HOME' not in os.environ:
+        new_env['HOME'] = tempfile.gettempdir()
     p = subprocess.Popen(
         [pandoc_path, '--version'],
         stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE)
+        stdout=subprocess.PIPE,
+        env=new_env)
     comm = p.communicate()
     out_lines = comm[0].decode().splitlines(False)
     if p.returncode != 0 or len(out_lines) == 0:


### PR DESCRIPTION
This PR fixes the problem described in #103 .

In #103, I suggested using `--data-dir` option, but it is not usable since pandoc ignores `--data-dir` option if `--version` is specified.

This PR takes another aproach; creates an environment which is local to `pandoc --version` and supply $HOME if it is not set.