### PR TITLE
Add possibility to use .lua custom writers as output format

### DIFF
--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -206,7 +206,10 @@ def _validate_formats(format, to, outputfile):
                 _get_base_format(format), ', '.join(from_formats)))
 
     base_to_format = _get_base_format(to)
-    if base_to_format not in to_formats:
+
+    file_extension = os.path.splitext(base_to_format)[1]
+
+    if base_to_format not in to_formats and file_extension != '.lua':
         raise RuntimeError(
             'Invalid output format! Expected one of these: ' +
             ', '.join(to_formats))


### PR DESCRIPTION
The pandoc format for custom writers is `pandoc -t data/sample.lua` from [official documentation](http://pandoc.org/MANUAL.html#custom-writers).
I've added a minimum necessary fix to work with custom writers from pypandoc, if you think it needs additional check procedures, please let me know.