### PR TITLE
Fix for pandoc 1.18

### DIFF
--- a/pypandoc/py3compat.py
+++ b/pypandoc/py3compat.py
@@ -48,5 +48,5 @@ if sys.version_info[0] >= 3:
 else:
     PY3 = False
 
-    string_types = (str, unicode)
-    unicode_type = unicode
+    string_types = (str, unicode)  # noqa: F821
+    unicode_type = unicode  # noqa: F821


### PR DESCRIPTION
pandoc 1.18 changed the way it lists input and output versions. We now try the
newer version first and if that fails the older version.

Tested on windows with 1.17.2 and 1.18

Closes: https://github.com/bebraw/pypandoc/issues/112