### PR TITLE
Enable PyPI uploads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ python:
  - 3.5 # otherwise we can't run tox 3.5 tests
 env:
   matrix:
+    - TOXENV=py35
     - TOXENV=py26
     - TOXENV=py27
     - TOXENV=py33
     - TOXENV=py34
-    - TOXENV=py35
     - TOXENV=pypy
     - TOXENV=flake8
 addons:
@@ -28,3 +28,14 @@ install:
 script:
   - ./pypandoc/files/pandoc -v
   - tox
+
+deploy:
+  provider: pypi
+  distributions: sdist
+  user: janschulz
+  password:
+    secure: uxmjO7Q0MP0YZb1pdAkKn7TdLdFU1lJqrnSR5DpjzPpJRlGMUph0MIrtHtU1CsbMya//Wwszae77pEqAIDpQ5mHlfF3mPxSO8TWvYu6XZdkmmTKf3rIaJgYoOIz1VdyHsti5SIHMBE749eUykTwNrqV4OR+lk3fpdZmy8shl7+U=
+  on:
+    tags: true
+    repo: bebraw/pypandoc
+    condition: $TOXENV == py35

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,22 +17,18 @@ environment:
     # See: http://www.appveyor.com/docs/installed-software#python
 
     - PYTHON: "C:\\Python27-x64"
-      TOXENV: py27
       PYTHON_VERSION: "2.7.x" # currently 2.7.9
       PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Python33-x64"
-      TOXENV: py33
       PYTHON_VERSION: "3.3.x" # currently 3.3.5
       PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Python34-x64"
-      TOXENV: py34
       PYTHON_VERSION: "3.4.x" # currently 3.4.3
       PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Python35-x64"
-      TOXENV: py35
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"
 
@@ -79,7 +75,6 @@ install:
   # about it being out of date.
   - "pip install --disable-pip-version-check --user --upgrade pip"
 
-  - "%CMD_IN_ENV% pip install tox"
   - "%CMD_IN_ENV% pip install twine wheel"
 
 build_script:
@@ -87,7 +82,7 @@ build_script:
 
 test_script:
   # Run the project tests
-  - "%CMD_IN_ENV% tox"
+  - "%CMD_IN_ENV% python tests.py"
 
 after_test:
   # If tests are successful, create binary packages for the project.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -100,6 +100,6 @@ artifacts:
 
 on_success:
   - ps: >-
-      if ($env:APPVEYOR_REPO_TAG) {
+      if ($env:APPVEYOR_REPO_TAG -eq "true") {
         twine upload dist/*.whl
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,6 @@
+cache:
+  - c:\miktex -> appveyor.yml
+
 environment:
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
   # /E:ON and /V:ON options are not enabled in the batch script intepreter
@@ -63,9 +66,9 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
   
-  # Install miktex to get pdflatex
-  - ps: Start-FileDownload 'http://mirrors.ctan.org/systems/win32/miktex/setup/miktex-portable.exe'
-  - 7z x miktex-portable.exe -oC:\miktex >NUL
+  # Install miktex to get pdflatex, if we don't get it from the cache
+  - if not exist c:\miktex\texmfs\install\miktex\bin\pdflatex.exe appveyor DownloadFile http://mirrors.ctan.org/systems/win32/miktex/setup/miktex-portable.exe
+  - if not exist c:\miktex\texmfs\install\miktex\bin\pdflatex.exe 7z x miktex-portable.exe -oC:\miktex >NUL
   - set "PATH=%PATH%;c:\miktex\texmfs\install\miktex\bin"
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,35 +13,23 @@ environment:
     # a later point release.
     # See: http://www.appveyor.com/docs/installed-software#python
 
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.x" # currently 2.7.9
-      PYTHON_ARCH: "32"
-
     - PYTHON: "C:\\Python27-x64"
+      TOXENV: py27
       PYTHON_VERSION: "2.7.x" # currently 2.7.9
       PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python33"
-      PYTHON_VERSION: "3.3.x" # currently 3.3.5
-      PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python33-x64"
+      TOXENV: py33
       PYTHON_VERSION: "3.3.x" # currently 3.3.5
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.x" # currently 3.4.3
-      PYTHON_ARCH: "32"
-
     - PYTHON: "C:\\Python34-x64"
+      TOXENV: py34
       PYTHON_VERSION: "3.4.x" # currently 3.4.3
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.x"
-      PYTHON_ARCH: "32"
-
     - PYTHON: "C:\\Python35-x64"
+      TOXENV: py35
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"
 
@@ -74,6 +62,12 @@ install:
   # Check that we have the expected version and architecture for Python
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+  
+  # Install miktex to get pdflatex
+  - ps: Start-FileDownload 'http://mirrors.ctan.org/systems/win32/miktex/setup/miktex-portable.exe'
+  - 7z x miktex-portable.exe -oC:\miktex >NUL
+  - set "PATH=%PATH%;c:\miktex\texmfs\install\miktex\bin"
+
 
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,11 @@
 environment:
-    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
-    # /E:ON and /V:ON options are not enabled in the batch script intepreter
-    # See: http://stackoverflow.com/a/13751649/163740
-    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
-    TWINE_PASSWORD:
-      secure: vwvitc1udvvzJrSNBbxQrtNKPACCOpSM3kteJK6UBR8=
-    TWINE_USERNAME: janschulz
+  # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+  # /E:ON and /V:ON options are not enabled in the batch script intepreter
+  # See: http://stackoverflow.com/a/13751649/163740
+  CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
+  TWINE_PASSWORD:
+    secure: vwvitc1udvvzJrSNBbxQrtNKPACCOpSM3kteJK6UBR8=
+  TWINE_USERNAME: janschulz
 
   matrix:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,6 +70,9 @@ install:
   - if not exist c:\miktex\texmfs\install\miktex\bin\pdflatex.exe appveyor DownloadFile http://mirrors.ctan.org/systems/win32/miktex/setup/miktex-portable.exe
   - if not exist c:\miktex\texmfs\install\miktex\bin\pdflatex.exe 7z x miktex-portable.exe -oC:\miktex >NUL
   - set "PATH=%PATH%;c:\miktex\texmfs\install\miktex\bin"
+  # autoinstall latex packages (0=no, 1=autoinstall, 2=ask)
+  # this adds this to the registry!
+  - initexmf --set-config-value "[MPM]AutoInstall=1"
 
 
   # Upgrade to the latest version of pip to avoid it displaying warnings

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,7 +80,7 @@ install:
   - "pip install --disable-pip-version-check --user --upgrade pip"
 
   - "%CMD_IN_ENV% pip install tox"
-  - "%CMD_IN_ENV% pip install twine"
+  - "%CMD_IN_ENV% pip install twine wheel"
 
 build_script:
   - "%CMD_IN_ENV% python setup.py download_pandoc"

--- a/setup.py
+++ b/setup.py
@@ -69,8 +69,8 @@ if is_build_wheel:
                 msg = "Including pandoc in wheel needs wheel >=0.27 but found %s.\nPlease update wheel!"
                 raise RuntimeError(msg % wheel.__version__)
         except ImportError:
-            # No wheel installed, the user will get an error at a different place...
-            pass
+            # the real error will happen further down...
+            print("No wheel installed, please install 'wheel'...")
         print("forcing platform specific wheel name...")
         from distutils.util import get_platform
         sys.argv.insert(pos_bdist_wheel + 1, '--plat-name')

--- a/tests.py
+++ b/tests.py
@@ -213,10 +213,6 @@ class TestPypandoc(unittest.TestCase):
         self.assertRaises(RuntimeError, f)
 
     def test_conversion_with_citeproc_filter(self):
-        if os.environ.get('CI', None):
-            print("Skipping: there is a bug with citeproc on travis.")
-            return
-
         # we just want to get a temp file name, where we can write to
         filters = ['pandoc-citeproc']
         written = pypandoc.convert('./filter_test.md', to='html', format='md',
@@ -289,10 +285,6 @@ class TestPypandoc(unittest.TestCase):
         self.assertTrue(isinstance(written, unicode_type))
 
     def test_conversion_from_non_plain_text_file(self):
-        if 'CI' in os.environ:
-            print("Skipping: travis is running on old pandoc, no docx")
-            return
-
         with closed_tempfile('.docx') as file_name:
             expected = u'some title{0}=========={0}{0}'.format(os.linesep)
             # let's just test conversion (to and) from docx, testing e.g. odt


### PR DESCRIPTION
* adds appveyor as a CI service (tests done without tox, because tox and windows seem to not play nicely, at least on py3.5: https://ci.appveyor.com/project/JanSchulz/pypandoc-apo32/build/1.0.24/job/7torqbx368ajagcf)
* adds uploads from travis and appveyor when a commit is tagged, using my (@janschulz) pypi account data