### PR TITLE
Fixed a crash with custom writers

### DIFF
--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -224,14 +224,14 @@ def _validate_formats(format, to, outputfile):
 
     base_to_format = _get_base_format(to)
 
-    file_extension = os.path.splitext(base_to_format)[1]
+    file_extension = os.path.splitext(to)[1]
 
     if (base_to_format not in to_formats and
         base_to_format != "pdf" and  # pdf is handled later # noqa: E127
         file_extension != '.lua'):
         raise RuntimeError(
-            'Invalid output format! Expected one of these: ' +
-            ', '.join(to_formats))
+            'Invalid output format! Got %s but expected one of these: %s' % (
+                 base_to_format, ', '.join(to_formats)))
 
     # list from https://github.com/jgm/pandoc/blob/master/pandoc.hs
     # `[...] where binaries = ["odt","docx","epub","epub3"] [...]`

--- a/tests.py
+++ b/tests.py
@@ -332,19 +332,19 @@ class TestPypandoc(unittest.TestCase):
 
         self.assertRaises(RuntimeError, f)
 
-        def f():
-            # outputfile needs to end in pdf
-            with closed_tempfile('.WRONG') as file_name:
+        # outputfile needs to end in pdf
+        with closed_tempfile('.WRONG') as file_name:
+            def f():
                 pypandoc.convert_text('#some title\n', to='pdf', format='md', outputfile=file_name)
 
-        self.assertRaises(RuntimeError, f)
+            self.assertRaises(RuntimeError, f)
 
-        def f():
-            # no extensions allowed
-            with closed_tempfile('.pdf') as file_name:
+        # no extensions allowed
+        with closed_tempfile('.pdf') as file_name:
+            def f():
                 pypandoc.convert_text('#some title\n', to='pdf+somethign', format='md', outputfile=file_name)
 
-        self.assertRaises(RuntimeError, f)
+            self.assertRaises(RuntimeError, f)
 
     def test_get_pandoc_path(self):
         result = pypandoc.get_pandoc_path()


### PR DESCRIPTION
When using a custom writer inside directories containing
either a + or - in the name, the file extension isn't
recognized properly because _get_base_format strips it
off. Can be triggered in the tests with:

mkdir /tmp/foo-bar/
TMPDIR=/tmp/foo-bar ./tests.py