### PR TITLE
Add Python 3.6 to the list of supported versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'
     ],


### PR DESCRIPTION
The test suite passes on Python 3.6, so I think it can safely be added to the list of supported versions.