### PR TITLE
Added quiet to _ensure_pandoc_path and extra paths for Windows installs of Pandoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,8 @@ Note that for citeproc tests to pass you'll need to have [pandoc-citeproc](https
 * [Paul Osborne](https://github.com/posborne) - Don't require pandoc to install pypandoc.
 * [Felix Yan](https://github.com/felixonmars) - Added installation instructions for Arch Linux.
 * [Kolen Cheung](https://github.com/ickc) - Implement `_get_pandoc_urls` for installing arbitrary version as well as the latest version of pandoc. Minor: README, Travis, setup.py.
-
+* [Rebecca Heineman](https://github.com/burgerbecky) - Added scanning code for finding pandoc in Windows
+ 
 ## License
 
 Pypandoc is available under MIT license. See LICENSE for more details. Pandoc itself is [available under the GPL2 license](https://github.com/jgm/pandoc/blob/master/COPYING.md).

--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -474,6 +474,13 @@ def _ensure_pandoc_path(quiet=False):
         # installed if it's an environment and the environment wasn't activated
         if pf == "win32":
             search_paths.append(os.path.join(sys.exec_prefix, "Scripts", "pandoc"))
+
+            # Since this only runs on Windows, use Windows slashes
+            if os.getenv('ProgramFiles', None):
+                search_paths.append(os.path.expandvars("${ProgramFiles}\\Pandoc\\Pandoc"))
+            if os.getenv('ProgramFiles(x86)', None):
+                search_paths.append(os.path.expandvars("${ProgramFiles(x86)}\\Pandoc\\Pandoc"))
+
         # bin can also be used on windows (conda at leats has it in path), so
         # include it unconditionally
         search_paths.append(os.path.join(sys.exec_prefix, "bin", "pandoc"))


### PR DESCRIPTION
Added the flag "quiet" to _ensure_pandoc_path to shut down output spew. enhanced ensure_pandoc_installed() to allow it to pass all parameters to download_pandoc() in case they need to be overridden