### PR TITLE
Avoid "DeprecationWarning: invalid escape sequence"

### DIFF
--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -332,7 +332,7 @@ def _get_base_format(format):
     appending +EXTENSION or -EXTENSION to the format name.
     Return the base format without any extensions.
     '''
-    return re.split('\+|-', format)[0]
+    return re.split(r'\+|-', format)[0]
 
 
 def get_pandoc_formats():
@@ -384,8 +384,8 @@ def get_pandoc_formats_pre_1_18():
     txt = ' '.join(help_text[1:help_text.index('Options:')])
 
     aux = txt.split('Output formats: ')
-    in_ = re.sub('Input\sformats:\s|\*|\[.*?\]', '', aux[0]).split(',')
-    out = re.sub('\*|\[.*?\]', '', aux[1]).split(',')
+    in_ = re.sub(r'Input\sformats:\s|\*|\[.*?\]', '', aux[0]).split(',')
+    out = re.sub(r'\*|\[.*?\]', '', aux[1]).split(',')
 
     return [f.strip() for f in in_], [f.strip() for f in out]
 


### PR DESCRIPTION
I get the deprecation warnings in Python 3.7 when running test cases that using pypandoc:

```
lib/python3.7/site-packages/pypandoc/__init__.py:339: DeprecationWarning: invalid escape sequence \+
  return re.split('\+|-', format)[0]
lib/python3.7/site-packages/pypandoc/__init__.py:391: DeprecationWarning: invalid escape sequence \s
  in_ = re.sub('Input\sformats:\s|\*|\[.*?\]', '', aux[0]).split(',')
lib/python3.7/site-packages/pypandoc/__init__.py:392: DeprecationWarning: invalid escape sequence \*
  out = re.sub('\*|\[.*?\]', '', aux[1]).split(',')
```

Warnings can be avoidable by using raw string at regular expressions.