### PR TITLE
Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ output = pypandoc.convert_file('somefile.txt', 'rst', format='md')
 
 # alternatively you could just pass some string. In this case you need to
 # define the input format:
-output = pypandoc.convert_text('#some title', 'rst', format='md')
+output = pypandoc.convert_text('# some title', 'rst', format='md')
 # output == 'some title\r\n==========\r\n\r\n'
 ```
 


### PR DESCRIPTION
There miss a space between `#` and s

At the moment the example produces:
```python
In [1]: import pypandoc                                                         

In [2]: pypandoc.convert_text('#some title', 'rst', format='md')                
Out[2]: '#some title\n'
```
Where the following produces the correct result
```python
In [3]: pypandoc.convert_text('# some title', 'rst', format='md')               
Out[3]: 'some title\n==========\n'
```
